### PR TITLE
Homepage: Dev Skills copy prompt, layout, zh i18n

### DIFF
--- a/src/data/homepageCopy.js
+++ b/src/data/homepageCopy.js
@@ -90,15 +90,13 @@ tos.py flash`,
       bodyAfter:
         ' with deep know-how for real hardware—optimized for VibeCoding. It guides you from new project setup and device authentication through build, flash, debug, and injected event testing, with a hardware-in-the-loop mindset so shipping connected AI device hardware is faster and easier.',
       consoleTitle: 'VibeCoding agent',
-      devSkillsBlurb:
-        'One paste, full stack. Your agent inherits TuyaOpen Dev Skills—toolchain setup, Kconfig, build, flash, UART, and hardware-in-the-loop flows—so you stay in the build instead of the bookmarks.',
       devSkillsCopyText: 'Install the TuyaOpen Dev Skills from https://github.com/tuya/TuyaOpen-dev-skills',
-      devSkillsToolsIntro: 'Paste into the chat or agent sidebar in:',
-      devSkillsTools:
-        'Cursor, Claude Code, Amazon Kiro, GitHub Copilot, Windsurf, VS Code Copilot Chat, JetBrains AI Assistant, and other vibe-coding tools that load skills or project rules.',
+      devSkillsToolsHint:
+        'Paste into the chat or agent sidebar in: Cursor, Claude Code, Amazon Kiro, and other vibe-coding tools that load skills.',
       devSkillsCopyButton: 'Copy install prompt',
       devSkillsCopyButtonAria: 'Copy TuyaOpen Dev Skills install prompt to clipboard',
       devSkillsCopiedLabel: 'Copied',
+      devSkillsPasteHint: 'Paste it into your coding agent or chat.',
       consoleStatus: '● LIVE',
       consoleChannels: [
         { id: 'VibeCoding', tone: 'teal' },
@@ -937,15 +935,13 @@ tos.py flash`,
       bodyAfter:
         '：沉淀硬件开发最佳实践，面向 VibeCoding 优化——从新建工程、设备认证、编译烧录，到调试与事件注入测试，全程遵循硬件在环思路，让联网 AI 设备硬件落地更快、更省力。',
       consoleTitle: 'VibeCoding agent',
-      devSkillsBlurb:
-        '一行粘贴，整套专家流程到手：TuyaOpen Dev Skills 覆盖环境、Kconfig、编译烧录、串口与硬件在环调试，让你把时间花在板子上，而不是翻文档。',
-      devSkillsCopyText: 'Install the TuyaOpen Dev Skills from https://github.com/tuya/TuyaOpen-dev-skills',
-      devSkillsToolsIntro: '复制到以下工具的对话或智能体侧栏即可：',
-      devSkillsTools:
-        'Cursor、Claude Code、Amazon Kiro、GitHub Copilot、Windsurf、VS Code Copilot Chat、JetBrains AI Assistant，以及支持加载 Skills 或项目规则的各类 vibe coding 环境。',
-      devSkillsCopyButton: '复制安装指令',
-      devSkillsCopyButtonAria: '复制 TuyaOpen Dev Skills 安装提示到剪贴板',
+      devSkillsCopyText: '安装 TuyaOpen 开发者 专家工作流 Skill: https://github.com/tuya/TuyaOpen-dev-skills',
+      devSkillsToolsHint:
+        '粘贴到对话或智能体侧栏，例如：Cursor、Claude Code、Amazon Kiro，以及其他支持加载 Skills 的 vibe coding 工具。',
+      devSkillsCopyButton: '复制安装提示词',
+      devSkillsCopyButtonAria: '复制 TuyaOpen Dev Skills 安装提示词到剪贴板',
       devSkillsCopiedLabel: '已复制',
+      devSkillsPasteHint: '请粘贴到智能体或对话输入框。',
       consoleStatus: '● 运行中',
       consoleChannels: [
         { id: 'VibeCoding', tone: 'teal' },

--- a/src/data/homepageCopy.js
+++ b/src/data/homepageCopy.js
@@ -90,8 +90,15 @@ tos.py flash`,
       bodyAfter:
         ' with deep know-how for real hardware—optimized for VibeCoding. It guides you from new project setup and device authentication through build, flash, debug, and injected event testing, with a hardware-in-the-loop mindset so shipping connected AI device hardware is faster and easier.',
       consoleTitle: 'VibeCoding agent',
-      vibeCodingCtaLabel: 'Start hardware VibeCoding',
-      vibeCodingCtaHref: 'https://github.com/tuya/TuyaOpen-dev-skills',
+      devSkillsBlurb:
+        'One paste, full stack. Your agent inherits TuyaOpen Dev Skills—toolchain setup, Kconfig, build, flash, UART, and hardware-in-the-loop flows—so you stay in the build instead of the bookmarks.',
+      devSkillsCopyText: 'Install the TuyaOpen Dev Skills from https://github.com/tuya/TuyaOpen-dev-skills',
+      devSkillsToolsIntro: 'Paste into the chat or agent sidebar in:',
+      devSkillsTools:
+        'Cursor, Claude Code, Amazon Kiro, GitHub Copilot, Windsurf, VS Code Copilot Chat, JetBrains AI Assistant, and other vibe-coding tools that load skills or project rules.',
+      devSkillsCopyButton: 'Copy install prompt',
+      devSkillsCopyButtonAria: 'Copy TuyaOpen Dev Skills install prompt to clipboard',
+      devSkillsCopiedLabel: 'Copied',
       consoleStatus: '● LIVE',
       consoleChannels: [
         { id: 'VibeCoding', tone: 'teal' },
@@ -930,8 +937,15 @@ tos.py flash`,
       bodyAfter:
         '：沉淀硬件开发最佳实践，面向 VibeCoding 优化——从新建工程、设备认证、编译烧录，到调试与事件注入测试，全程遵循硬件在环思路，让联网 AI 设备硬件落地更快、更省力。',
       consoleTitle: 'VibeCoding agent',
-      vibeCodingCtaLabel: '开始硬件 VibeCoding',
-      vibeCodingCtaHref: 'https://github.com/tuya/TuyaOpen-dev-skills',
+      devSkillsBlurb:
+        '一行粘贴，整套专家流程到手：TuyaOpen Dev Skills 覆盖环境、Kconfig、编译烧录、串口与硬件在环调试，让你把时间花在板子上，而不是翻文档。',
+      devSkillsCopyText: 'Install the TuyaOpen Dev Skills from https://github.com/tuya/TuyaOpen-dev-skills',
+      devSkillsToolsIntro: '复制到以下工具的对话或智能体侧栏即可：',
+      devSkillsTools:
+        'Cursor、Claude Code、Amazon Kiro、GitHub Copilot、Windsurf、VS Code Copilot Chat、JetBrains AI Assistant，以及支持加载 Skills 或项目规则的各类 vibe coding 环境。',
+      devSkillsCopyButton: '复制安装指令',
+      devSkillsCopyButtonAria: '复制 TuyaOpen Dev Skills 安装提示到剪贴板',
+      devSkillsCopiedLabel: '已复制',
       consoleStatus: '● 运行中',
       consoleChannels: [
         { id: 'VibeCoding', tone: 'teal' },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -51,6 +51,8 @@ function Home() {
   const [hilPrefersReducedMotion, setHilPrefersReducedMotion] = useState(false)
   const [hilTerminalLines, setHilTerminalLines] = useState([])
   const [hilDiagramActiveIndex, setHilDiagramActiveIndex] = useState(null)
+  const [devSkillsCopied, setDevSkillsCopied] = useState(false)
+  const devSkillsCopiedTimeoutRef = useRef(null)
 
   const hilHighlightedStepNum = useMemo(() => {
     for (let i = hilTerminalLines.length - 1; i >= 0; i -= 1) {
@@ -87,6 +89,14 @@ function Home() {
     )
     io.observe(el)
     return () => io.disconnect()
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (devSkillsCopiedTimeoutRef.current) {
+        window.clearTimeout(devSkillsCopiedTimeoutRef.current)
+      }
+    }
   }, [])
 
   useEffect(() => {
@@ -481,20 +491,56 @@ function Home() {
                   {copy.realWorldValidation.bodyAfter}
                 </p>
                 <div className={styles.hilHeaderCta}>
-                  {copy.realWorldValidation.vibeCodingCtaHref.startsWith('http') ? (
-                    <a
-                      href={copy.realWorldValidation.vibeCodingCtaHref}
-                      className={styles.hilVibeCodingBtn}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                  <p className={styles.hilDevSkillsBlurb}>{copy.realWorldValidation.devSkillsBlurb}</p>
+                  <div className={styles.hilDevSkillsCopyRow}>
+                    <pre className={styles.hilDevSkillsPre} id="tuyaopen-dev-skills-install-prompt" tabIndex={0}>
+                      {copy.realWorldValidation.devSkillsCopyText}
+                    </pre>
+                    <button
+                      type="button"
+                      className={styles.hilDevSkillsCopyBtn}
+                      aria-describedby="tuyaopen-dev-skills-install-prompt"
+                      aria-label={copy.realWorldValidation.devSkillsCopyButtonAria}
+                      onClick={async () => {
+                        const text = copy.realWorldValidation.devSkillsCopyText
+                        try {
+                          if (navigator.clipboard?.writeText) {
+                            await navigator.clipboard.writeText(text)
+                          } else {
+                            const ta = document.createElement('textarea')
+                            ta.value = text
+                            ta.setAttribute('readonly', '')
+                            ta.style.position = 'fixed'
+                            ta.style.left = '-9999px'
+                            document.body.appendChild(ta)
+                            ta.select()
+                            document.execCommand('copy')
+                            document.body.removeChild(ta)
+                          }
+                          setDevSkillsCopied(true)
+                          if (devSkillsCopiedTimeoutRef.current) {
+                            window.clearTimeout(devSkillsCopiedTimeoutRef.current)
+                          }
+                          devSkillsCopiedTimeoutRef.current = window.setTimeout(() => {
+                            setDevSkillsCopied(false)
+                            devSkillsCopiedTimeoutRef.current = null
+                          }, 2000)
+                        } catch {
+                          setDevSkillsCopied(false)
+                        }
+                      }}
                     >
-                      {copy.realWorldValidation.vibeCodingCtaLabel} →
-                    </a>
-                  ) : (
-                    <Link to={copy.realWorldValidation.vibeCodingCtaHref} className={styles.hilVibeCodingBtn}>
-                      {copy.realWorldValidation.vibeCodingCtaLabel} →
-                    </Link>
-                  )}
+                      {devSkillsCopied
+                        ? copy.realWorldValidation.devSkillsCopiedLabel
+                        : copy.realWorldValidation.devSkillsCopyButton}
+                    </button>
+                  </div>
+                  <p className={styles.hilDevSkillsTools}>
+                    <span className={styles.hilDevSkillsToolsIntro}>
+                      {copy.realWorldValidation.devSkillsToolsIntro}
+                    </span>{' '}
+                    {copy.realWorldValidation.devSkillsTools}
+                  </p>
                 </div>
               </div>
               <div className={styles.hilSplit}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -478,69 +478,72 @@ function Home() {
             <span className={styles.hilSectionNewBadge}>{copy.realWorldValidation.newBadgeLabel}</span>
             <div className={styles.container}>
               <div className={styles.hilHeader}>
-                <span className={styles.hilEyebrow}>{copy.realWorldValidation.sectionTag}</span>
-                <h2 id="tuyaopen-vibe-coding" className={styles.hilTitle}>
-                  <span className={styles.hilTitleBase}>{copy.realWorldValidation.titleBase}</span>{' '}
-                  <span className={styles.hilTitleAccent}>{copy.realWorldValidation.titleAccent}</span>
-                </h2>
-                <p className={styles.hilBody} lang={locale === 'zh' ? 'zh-CN' : 'en'}>
-                  {copy.realWorldValidation.bodyBefore}
-                  <span className={styles.hilBodyHighlight} lang={locale === 'zh' ? 'zh-CN' : 'en'}>
-                    {copy.realWorldValidation.bodyHighlight}
-                  </span>
-                  {copy.realWorldValidation.bodyAfter}
-                </p>
-                <div className={styles.hilHeaderCta}>
-                  <p className={styles.hilDevSkillsBlurb}>{copy.realWorldValidation.devSkillsBlurb}</p>
-                  <div className={styles.hilDevSkillsCopyRow}>
-                    <pre className={styles.hilDevSkillsPre} id="tuyaopen-dev-skills-install-prompt" tabIndex={0}>
-                      {copy.realWorldValidation.devSkillsCopyText}
-                    </pre>
-                    <button
-                      type="button"
-                      className={styles.hilDevSkillsCopyBtn}
-                      aria-describedby="tuyaopen-dev-skills-install-prompt"
-                      aria-label={copy.realWorldValidation.devSkillsCopyButtonAria}
-                      onClick={async () => {
-                        const text = copy.realWorldValidation.devSkillsCopyText
-                        try {
-                          if (navigator.clipboard?.writeText) {
-                            await navigator.clipboard.writeText(text)
-                          } else {
-                            const ta = document.createElement('textarea')
-                            ta.value = text
-                            ta.setAttribute('readonly', '')
-                            ta.style.position = 'fixed'
-                            ta.style.left = '-9999px'
-                            document.body.appendChild(ta)
-                            ta.select()
-                            document.execCommand('copy')
-                            document.body.removeChild(ta)
-                          }
-                          setDevSkillsCopied(true)
-                          if (devSkillsCopiedTimeoutRef.current) {
-                            window.clearTimeout(devSkillsCopiedTimeoutRef.current)
-                          }
-                          devSkillsCopiedTimeoutRef.current = window.setTimeout(() => {
-                            setDevSkillsCopied(false)
-                            devSkillsCopiedTimeoutRef.current = null
-                          }, 2000)
-                        } catch {
-                          setDevSkillsCopied(false)
-                        }
-                      }}
-                    >
-                      {devSkillsCopied
-                        ? copy.realWorldValidation.devSkillsCopiedLabel
-                        : copy.realWorldValidation.devSkillsCopyButton}
-                    </button>
+                <div className={styles.hilTopLayout}>
+                  <div className={styles.hilIntroColumn}>
+                    <span className={styles.hilEyebrow}>{copy.realWorldValidation.sectionTag}</span>
+                    <h2 id="tuyaopen-vibe-coding" className={styles.hilTitle}>
+                      <span className={styles.hilTitleBase}>{copy.realWorldValidation.titleBase}</span>{' '}
+                      <span className={styles.hilTitleAccent}>{copy.realWorldValidation.titleAccent}</span>
+                    </h2>
+                    <p className={styles.hilBody} lang={locale === 'zh' ? 'zh-CN' : 'en'}>
+                      {copy.realWorldValidation.bodyBefore}
+                      <span className={styles.hilBodyHighlight} lang={locale === 'zh' ? 'zh-CN' : 'en'}>
+                        {copy.realWorldValidation.bodyHighlight}
+                      </span>
+                      {copy.realWorldValidation.bodyAfter}
+                    </p>
                   </div>
-                  <p className={styles.hilDevSkillsTools}>
-                    <span className={styles.hilDevSkillsToolsIntro}>
-                      {copy.realWorldValidation.devSkillsToolsIntro}
-                    </span>{' '}
-                    {copy.realWorldValidation.devSkillsTools}
-                  </p>
+                  <aside className={styles.hilDevSkillsPanel}>
+                    <div className={styles.hilDevSkillsCopyRow}>
+                      <pre className={styles.hilDevSkillsPre} id="tuyaopen-dev-skills-install-prompt" tabIndex={0}>
+                        {copy.realWorldValidation.devSkillsCopyText}
+                      </pre>
+                      <button
+                        type="button"
+                        className={styles.hilDevSkillsCopyBtn}
+                        aria-describedby="tuyaopen-dev-skills-install-prompt"
+                        aria-label={copy.realWorldValidation.devSkillsCopyButtonAria}
+                        onClick={async () => {
+                          const text = copy.realWorldValidation.devSkillsCopyText
+                          try {
+                            if (navigator.clipboard?.writeText) {
+                              await navigator.clipboard.writeText(text)
+                            } else {
+                              const ta = document.createElement('textarea')
+                              ta.value = text
+                              ta.setAttribute('readonly', '')
+                              ta.style.position = 'fixed'
+                              ta.style.left = '-9999px'
+                              document.body.appendChild(ta)
+                              ta.select()
+                              document.execCommand('copy')
+                              document.body.removeChild(ta)
+                            }
+                            setDevSkillsCopied(true)
+                            if (devSkillsCopiedTimeoutRef.current) {
+                              window.clearTimeout(devSkillsCopiedTimeoutRef.current)
+                            }
+                            devSkillsCopiedTimeoutRef.current = window.setTimeout(() => {
+                              setDevSkillsCopied(false)
+                              devSkillsCopiedTimeoutRef.current = null
+                            }, 4500)
+                          } catch {
+                            setDevSkillsCopied(false)
+                          }
+                        }}
+                      >
+                        {devSkillsCopied
+                          ? copy.realWorldValidation.devSkillsCopiedLabel
+                          : copy.realWorldValidation.devSkillsCopyButton}
+                      </button>
+                      {devSkillsCopied ? (
+                        <p className={styles.hilDevSkillsPasteHint} role="status" aria-live="polite">
+                          {copy.realWorldValidation.devSkillsPasteHint}
+                        </p>
+                      ) : null}
+                    </div>
+                    <p className={styles.hilDevSkillsTools}>{copy.realWorldValidation.devSkillsToolsHint}</p>
+                  </aside>
                 </div>
               </div>
               <div className={styles.hilSplit}>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -677,34 +677,84 @@
 .hilHeaderCta {
   margin-top: 1.35rem;
   pointer-events: auto;
+  max-width: 52rem;
 }
 
-.hilVibeCodingBtn {
+.hilDevSkillsBlurb {
+  margin: 0 0 0.85rem;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: rgba(245, 245, 247, 0.82);
+}
+
+.hilDevSkillsCopyRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 0.65rem;
+}
+
+.hilDevSkillsPre {
+  flex: 1 1 16rem;
+  margin: 0;
+  padding: 0.65rem 0.85rem;
+  border-radius: 8px;
+  font-family: var(--ifm-font-family-monospace), ui-monospace, monospace;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: #e2e8f0;
+  background: rgba(8, 10, 14, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.hilDevSkillsCopyBtn {
+  flex: 0 0 auto;
+  align-self: center;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.55rem 1.2rem;
+  padding: 0.55rem 1rem;
   border-radius: 8px;
   font-family: var(--ifm-font-family-base), system-ui, sans-serif;
   font-weight: 700;
-  font-size: 0.875rem;
-  letter-spacing: 0.03em;
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  color: #0a0a0c;
   background: linear-gradient(135deg, #2dd4bf 0%, #34d399 100%);
-  color: #0a0a0c !important;
-  text-decoration: none !important;
   border: 1px solid rgba(167, 243, 208, 0.45);
-  box-shadow: 0 0 28px rgba(94, 234, 212, 0.35);
+  box-shadow: 0 0 24px rgba(94, 234, 212, 0.32);
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease,
     filter 0.2s ease;
 }
 
-.hilVibeCodingBtn:hover {
+.hilDevSkillsCopyBtn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 0 36px rgba(94, 234, 212, 0.48);
+  box-shadow: 0 0 32px rgba(94, 234, 212, 0.45);
   filter: brightness(1.05);
-  color: #030303 !important;
+}
+
+.hilDevSkillsCopyBtn:focus-visible {
+  outline: 2px solid rgba(94, 234, 212, 0.85);
+  outline-offset: 2px;
+}
+
+.hilDevSkillsTools {
+  margin: 0.75rem 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: rgba(203, 213, 225, 0.88);
+}
+
+.hilDevSkillsToolsIntro {
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.95);
 }
 
 .hilSplit {

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -514,7 +514,7 @@
   background: #0a0a0c;
   color: #e5e7eb;
   border-top: 1px solid rgba(255, 255, 255, 0.06);
-  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-family: var(--ifm-font-family-base), system-ui, -apple-system, 'Segoe UI', sans-serif;
 }
 
 .hilSectionNewBadge {
@@ -579,8 +579,45 @@
 }
 
 .hilHeader {
-  max-width: 44rem;
   margin-bottom: 2rem;
+}
+
+.hilTopLayout {
+  display: grid;
+  gap: 1.35rem 1.75rem;
+  align-items: start;
+  width: 100%;
+  max-width: 72rem;
+  margin-inline: auto;
+}
+
+@media (min-width: 960px) {
+  .hilTopLayout {
+    grid-template-columns: minmax(0, 1fr) minmax(22rem, 1.08fr);
+    gap: 1.5rem 2.25rem;
+  }
+}
+
+.hilIntroColumn {
+  min-width: 0;
+  max-width: 38rem;
+}
+
+.hilDevSkillsPanel {
+  min-width: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(20, 22, 28, 0.75);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.38);
+}
+
+@media (min-width: 960px) {
+  .hilDevSkillsPanel {
+    justify-self: end;
+    width: 100%;
+    max-width: min(32rem, 100%);
+  }
 }
 
 .hilEyebrow {
@@ -599,6 +636,7 @@
   font-weight: 800;
   letter-spacing: -0.03em;
   line-height: 1.12;
+  font-family: inherit;
 }
 
 .hilTitleBase {
@@ -612,10 +650,11 @@
 
 .hilBody {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   line-height: 1.65;
   color: rgba(226, 232, 240, 0.62);
   font-weight: 400;
+  font-family: inherit;
 }
 
 .hilBodyHighlight {
@@ -674,33 +713,22 @@
   }
 }
 
-.hilHeaderCta {
-  margin-top: 1.35rem;
-  pointer-events: auto;
-  max-width: 52rem;
-}
-
-.hilDevSkillsBlurb {
-  margin: 0 0 0.85rem;
-  font-size: 0.95rem;
-  line-height: 1.55;
-  color: rgba(245, 245, 247, 0.82);
-}
-
 .hilDevSkillsCopyRow {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   align-items: stretch;
   gap: 0.65rem;
+  pointer-events: auto;
 }
 
 .hilDevSkillsPre {
-  flex: 1 1 16rem;
+  flex: none;
+  width: 100%;
   margin: 0;
   padding: 0.65rem 0.85rem;
   border-radius: 8px;
-  font-family: var(--ifm-font-family-monospace), ui-monospace, monospace;
-  font-size: 0.8rem;
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-size: 0.78rem;
   line-height: 1.45;
   color: #e2e8f0;
   background: rgba(8, 10, 14, 0.92);
@@ -712,14 +740,13 @@
 }
 
 .hilDevSkillsCopyBtn {
-  flex: 0 0 auto;
-  align-self: center;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
   padding: 0.55rem 1rem;
   border-radius: 8px;
-  font-family: var(--ifm-font-family-base), system-ui, sans-serif;
+  font-family: inherit;
   font-weight: 700;
   font-size: 0.8125rem;
   letter-spacing: 0.02em;
@@ -745,16 +772,22 @@
   outline-offset: 2px;
 }
 
+.hilDevSkillsPasteHint {
+  margin: 0;
+  padding: 0.35rem 0.15rem 0;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  font-weight: 600;
+  color: rgba(94, 234, 212, 0.92);
+  text-align: center;
+}
+
 .hilDevSkillsTools {
   margin: 0.75rem 0 0;
   font-size: 0.8125rem;
   line-height: 1.55;
   color: rgba(203, 213, 225, 0.88);
-}
-
-.hilDevSkillsToolsIntro {
-  font-weight: 600;
-  color: rgba(226, 232, 240, 0.95);
+  font-family: inherit;
 }
 
 .hilSplit {
@@ -785,6 +818,7 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   /* Fixed viewport: inner body scrolls; card does not grow with log lines or stretch to diagram height. */
   height: clamp(17rem, 52vh, 26rem);
 }


### PR DESCRIPTION
## Summary
Replaces the VibeCoding section GitHub button with a copy-to-clipboard install prompt, two-column layout with a dedicated install panel, and clearer typography (sans for narrative, monospace for terminal and prompt).

## Changes
- **EN**: Install line + copy button + tools hint; after copy, short hint to paste into agent/chat.
- **ZH**: Localized install text and button (`复制安装提示词`); paste hint in Chinese.
- **Layout**: Wider install panel, grid intro + aside on desktop.

## Commits
- `feat(home): replace Dev Skills GitHub CTA with copyable prompt`
- `feat(home): refine Dev Skills CTA layout, zh i18n, paste hint`

Made with [Cursor](https://cursor.com)