### PR TITLE
feat(theme): navbar GitHub star button + Ecosystem/Legal nav updates

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -148,12 +148,19 @@ const config = {
           ],
         },
         {
-          to: 'blog',
-          label: 'Blog',
-        },
-        {
-          to: '/projects',
-          label: 'Projects',
+          type: 'dropdown',
+          label: 'Ecosystem',
+          position: 'left',
+          items: [
+            { label: 'Projects', to: '/projects' },
+            { label: 'Blog', to: 'blog' },
+            {
+              label: 'Event Registration',
+              href: 'https://images.tuyacn.com/rms-static/fe11d250-54e9-11f1-8d53-258e63d3fe0e-1779349939189.html?tyName=event-registration.html',
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            },
+          ],
         },
         {
           type: 'dropdown',
@@ -166,12 +173,6 @@ const config = {
         },
         {
           type: 'localeDropdown',
-          position: 'right',
-        },
-        {
-          href: 'https://github.com/tuya/TuyaOpen',
-          className: 'header-github-link',
-          'aria-label': 'GitHub',
           position: 'right',
         },
       ],
@@ -286,9 +287,38 @@ const config = {
             },
           ],
         },
+        {
+          title: 'Legal',
+          items: [
+            {
+              label: 'Terms of Service',
+              href: 'https://auth.tuya.com/policies/service',
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            },
+            {
+              label: 'Legal Statement',
+              href: 'https://auth.tuya.com/policies/legal',
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            },
+            {
+              label: 'Tuya Privacy Policy',
+              href: 'https://auth.tuya.com/policies/privacy',
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            },
+            {
+              label: 'Tuya California Privacy Notice',
+              href: 'https://auth.tuya.com/policies/CAprivacynotice',
+              target: '_blank',
+              rel: 'noopener noreferrer',
+            },
+          ],
+        },
       ],
       copyright: `
-        <p style="font-weight: 500;">Copyright © TuyaOpen Authors ${new Date().getFullYear()} | Documentation Distributed under Apache License Version 2.0</p>
+        <p style="font-weight: 500;">Copyright © TuyaOpen Authors ${new Date().getFullYear()} | Documentation Distributed under <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">Apache License Version 2.0</a></p>
       `,
     },
     prism: {

--- a/i18n/zh/docusaurus-theme-classic/footer.json
+++ b/i18n/zh/docusaurus-theme-classic/footer.json
@@ -64,7 +64,7 @@
     "description": "The label of footer link with label=Thanks for the technology illustrations by Storyset linking to https://storyset.com/technology"
   },
   "copyright": {
-    "message": "\n        <p style=\"font-weight: 500;\">版权所有 © TuyaOpen Authors 2025 | Documentation Distributed under Apache License Version 2.0</p>\n",
+    "message": "\n        <p style=\"font-weight: 500;\">版权所有 © TuyaOpen Authors 2025 | Documentation Distributed under <a href=\"https://www.apache.org/licenses/LICENSE-2.0\" target=\"_blank\" rel=\"noopener noreferrer\">Apache License Version 2.0</a></p>\n",
     "description": "The footer copyright"
   },
   "link.item.label.Service": {
@@ -154,5 +154,25 @@
   "link.item.label.Projects": {
     "message": "Projects",
     "description": "The label of footer link with label=Projects linking to /projects"
+  },
+  "link.title.Legal": {
+    "message": "法律",
+    "description": "The title of the footer links column with title=Legal in the footer"
+  },
+  "link.item.label.Terms of Service": {
+    "message": "服务条款",
+    "description": "The label of footer link with label=Terms of Service linking to https://auth.tuya.com/policies/service"
+  },
+  "link.item.label.Legal Statement": {
+    "message": "法律声明",
+    "description": "The label of footer link with label=Legal Statement linking to https://auth.tuya.com/policies/legal"
+  },
+  "link.item.label.Tuya Privacy Policy": {
+    "message": "涂鸦隐私政策",
+    "description": "The label of footer link with label=Tuya Privacy Policy linking to https://auth.tuya.com/policies/privacy"
+  },
+  "link.item.label.Tuya California Privacy Notice": {
+    "message": "Tuya 加州隐私声明",
+    "description": "The label of footer link with label=Tuya California Privacy Notice linking to https://auth.tuya.com/policies/CAprivacynotice"
   }
 }

--- a/i18n/zh/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh/docusaurus-theme-classic/navbar.json
@@ -59,6 +59,14 @@
     "message": "项目",
     "description": "Navbar item with label Projects"
   },
+  "item.label.Ecosystem": {
+    "message": "生态",
+    "description": "Navbar dropdown with label Ecosystem"
+  },
+  "item.label.Event Registration": {
+    "message": "活动报名",
+    "description": "Navbar item with label Event Registration"
+  },
   "item.label.About Us": {
     "message": "关于我们",
     "description": "Navbar dropdown with label About Us"

--- a/src/data/tuyaOpenIdeCopy.js
+++ b/src/data/tuyaOpenIdeCopy.js
@@ -276,8 +276,8 @@ export const tuyaOpenIdeCopy = {
         label: 'VS Code users',
         title: 'Download & install the .vsix',
         desc: 'The extension is published on the Open VSX registry. Download the package and install it manually in VS Code.',
-        downloadCta: 'Download .vsix · v0.0.12',
-        downloadUrl: 'https://open-vsx.org/api/TuyaOpen/TuyaOpenIDE/0.0.12/file/TuyaOpen.TuyaOpenIDE-0.0.12.vsix',
+        downloadCta: 'Download .vsix · v0.0.13',
+        downloadUrl: 'https://open-vsx.org/api/TuyaOpen/TuyaOpenIDE/0.0.13/file/TuyaOpen.TuyaOpenIDE-0.0.13.vsix',
         guideTitle: 'How to install',
         steps: [
           'Download the .vsix file using the button above.',
@@ -790,8 +790,8 @@ export const tuyaOpenIdeCopy = {
         label: 'VS Code 用户',
         title: '下载并安装 .vsix',
         desc: '扩展已发布在 Open VSX 仓库。下载安装包后，在 VS Code 中手动安装。',
-        downloadCta: '下载 .vsix · v0.0.12',
-        downloadUrl: 'https://open-vsx.org/api/TuyaOpen/TuyaOpenIDE/0.0.12/file/TuyaOpen.TuyaOpenIDE-0.0.12.vsix',
+        downloadCta: '下载 .vsix · v0.0.13',
+        downloadUrl: 'https://open-vsx.org/api/TuyaOpen/TuyaOpenIDE/0.0.13/file/TuyaOpen.TuyaOpenIDE-0.0.13.vsix',
         guideTitle: '安装步骤',
         steps: [
           '点击上方按钮下载 .vsix 文件。',

--- a/src/pages/about-us.module.css
+++ b/src/pages/about-us.module.css
@@ -14,7 +14,12 @@
     system-ui,
     sans-serif;
   background: var(--ifm-background-color);
-  overflow-x: hidden;
+  /* `clip` (not `hidden`) so this element does NOT become a scroll container.
+   * `overflow-x: hidden` forces `overflow-y` to compute to `auto`, which would
+   * make .page the sticky scroll container for .leftPanel — offsetting its
+   * `top: navbar-height` from .page's own top and opening a ~navbar-height gap
+   * under the navbar. `clip` clips horizontal bleed without that side effect. */
+  overflow-x: clip;
 }
 
 /* ---------------------------------------------------------------------------

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -150,9 +150,10 @@ const content = {
       ],
     },
     compare: {
-      tag: 'Full comparison',
-      title: 'What each tier unlocks',
-      subtitle: 'A feature-by-feature look, drawn straight from the TuyaOpen docs.',
+      tag: 'Compare tiers',
+      title: 'Start free, scale as you grow',
+      subtitle:
+        'The same open-source framework at every tier — pay once per device, only when it connects to Tuya Cloud.',
       cols: [
         { name: 'Open Source', price: 'Free' },
         { name: 'IoT', price: '¥5 / device' },
@@ -167,6 +168,7 @@ const content = {
             ['Arduino, Lua & MicroPython', true, true, true],
             ['11+ chips (T-series, ESP32, Pi…)', true, true, true],
             ['Serial debug & tyutool flashing', true, true, true],
+            ['TuyaOpen IDE for development', true, true, true],
           ],
         },
         {
@@ -284,7 +286,7 @@ cGuDnU2YxjHJldjxxxxxxxxxxxxxxxxx
         },
         {
           q: 'Are AI tokens included in the ¥12 license?',
-          a: 'The ¥12 license unlocks AI capabilities. Actual AI usage — LLM tokens, ASR minutes, TTS characters — is metered separately by use. See the licensing guide for the breakdown.',
+          a: 'The ¥12 license unlocks the full AI stack. For now, AI usage — LLM tokens, ASR minutes, TTS characters — is uncapped and included at no extra cost. We reserve the right to introduce usage-based billing in the future, with advance notice.',
         },
         {
           q: 'Do TuyaOS licenses work with TuyaOpen?',
@@ -434,9 +436,9 @@ cGuDnU2YxjHJldjxxxxxxxxxxxxxxxxx
       ],
     },
     compare: {
-      tag: '完整对比',
-      title: '各档位解锁的能力',
-      subtitle: '逐项对比，内容直接取自 TuyaOpen 文档。',
+      tag: '档位对比',
+      title: '免费起步，按需升级',
+      subtitle: '每个档位共享同一套开源框架 —— 仅当设备接入涂鸦云时，才按设备一次性付费。',
       cols: [
         { name: '开源开发者', price: '免费' },
         { name: 'IoT', price: '¥5 / 设备' },
@@ -451,6 +453,7 @@ cGuDnU2YxjHJldjxxxxxxxxxxxxxxxxx
             ['Arduino、Lua 与 MicroPython', true, true, true],
             ['11+ 芯片（T 系列、ESP32、树莓派…）', true, true, true],
             ['串口调试与 tyutool 烧录', true, true, true],
+            ['TuyaOpen IDE 开发环境', true, true, true],
           ],
         },
         {
@@ -568,7 +571,7 @@ cGuDnU2YxjHJldjxxxxxxxxxxxxxxxxx
         },
         {
           q: '¥12 授权是否包含 AI tokens？',
-          a: '¥12 授权解锁 AI 能力。实际 AI 用量 —— 大模型 token、ASR 时长、TTS 字符 —— 按使用单独计量。明细见授权指南。',
+          a: '¥12 授权解锁完整 AI 能力。目前 AI 用量 —— 大模型 token、ASR 时长、TTS 字符 —— 不设上限，且不额外收费。我们保留未来按量计费的权利，并将提前通知。',
         },
         {
           q: 'TuyaOS 授权能用于 TuyaOpen 吗？',
@@ -634,6 +637,63 @@ function Cell({ value }) {
   if (value === true) return <span className={styles.tick}>✓</span>
   if (value === false) return <span className={styles.cross}>—</span>
   return <span className={styles.cellText}>{value}</span>
+}
+
+/*
+ * Optional deep-links from each comparison-table feature to its dedicated doc.
+ * Shared across locales — parallel to `compare.groups` / `group.rows` by index.
+ * A `null` entry renders the label as plain text (no doc exists for it yet).
+ */
+const compareLinks = [
+  // Framework & tooling
+  [
+    '/docs/about-tuyaopen',
+    '/docs/tos-tools/tos-guide',
+    '/docs/hardware/tuya-t5/develop-with-Arduino/Introduction',
+    '/docs/hardware',
+    '/docs/tos-tools/tools-tyutool',
+    '/tuyaopen-ide', // TuyaOpen IDE
+  ],
+  // Connectivity & peripherals
+  [
+    '/docs/peripheral/tutorials/tal-wifi-api',
+    null, // Local LAN control
+    '/docs/peripheral/support_peripheral_list',
+    '/docs/tkl-api/tkl_gpio',
+    '/docs/peripheral/tutorials/http-client-tutorial',
+  ],
+  // Tuya Cloud (IoT)
+  [
+    '/docs/cloud/iot-client/tuya-iot-client-reference',
+    null, // Smart Life app control
+    '/docs/cloud/iot-client/tuya-iot-client-reference',
+    '/docs/cloud/tuya-cloud/device-cloud-binding',
+    '/docs/quick-start/firmware-ota',
+    '/docs/cloud/tuya-cloud/creating-new-product',
+    null, // Custom mini-app control panel
+  ],
+  // Multimodal AI
+  [
+    null, // Wake-word detection
+    '/docs/cloud/device-ai/ai-components/ai-audio-input',
+    '/docs/cloud/device-ai/ai-components/ai-agent',
+    '/docs/cloud/device-ai/ai-components/ai-video-input',
+    '/docs/cloud/device-ai/ai-components/ai-mcp-tools',
+    '/docs/cloud/device-ai/ai-components/ai-skill',
+    '/docs/cloud/tuya-cloud/ai-agent/ai-agent-dev-platform',
+  ],
+  // Production & support — no dedicated docs
+  [],
+]
+
+function FeatureLabel({ label, href, base }) {
+  if (!href) return <span className={styles.featurePlain}>{label}</span>
+  const to = href.startsWith('/') ? `${base}${href}` : href
+  return (
+    <Link className={styles.featureLink} to={to}>
+      {label}
+    </Link>
+  )
 }
 
 /* ----------------------------------------------------------------------- */
@@ -860,11 +920,14 @@ export default function Pricing() {
                   {c.compare.groups.map((group, gi) => (
                     <React.Fragment key={gi}>
                       <tr className={styles.groupRow}>
-                        <td colSpan={4}>{group.name}</td>
+                        <td colSpan={3}>{group.name}</td>
+                        <td className={styles.colPopular} aria-hidden />
                       </tr>
                       {group.rows.map((row, ri) => (
                         <tr key={ri}>
-                          <td>{row[0]}</td>
+                          <td>
+                            <FeatureLabel label={row[0]} href={compareLinks[gi]?.[ri]} base={base} />
+                          </td>
                           <td>
                             <Cell value={row[1]} />
                           </td>

--- a/src/pages/pricing.module.css
+++ b/src/pages/pricing.module.css
@@ -980,23 +980,25 @@
 /* ----------------------------------------------- Comparison table */
 .compareWrap {
   overflow-x: auto;
-  border: 1px solid var(--neutral-200);
-  border-radius: 16px;
-  background: #fff;
-}
-
-[data-theme='dark'] .compareWrap {
-  background: var(--neutral-800);
-  border-color: var(--neutral-700);
+  /* Transparent top strip gives the featured cap room to protrude — the table
+     background lives on the table itself, so it aligns to the real table. */
+  padding-top: 12px;
 }
 
 .compareTable {
   display: table;
   width: 100%;
   min-width: 640px;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   font-size: 0.92rem;
   table-layout: fixed;
+  background: #fff;
+  border-radius: 0 0 16px 16px;
+}
+
+[data-theme='dark'] .compareTable {
+  background: var(--neutral-800);
 }
 
 .compareTable th,
@@ -1054,12 +1056,69 @@
   color: var(--brand-primary-light);
 }
 
+/* Highlighted (featured) column — one continuous card that runs the whole
+   height, punching through the section dividers, bounded by a colorful edge.
+   The left/right edges are drawn per-cell (violet → accent gradient) so the
+   frame stays unbroken even behind the grey group dividers. */
 .colPopular {
-  background: rgba(124, 92, 255, 0.05);
+  background: rgba(124, 92, 255, 0.055);
+  border-left: 2px solid var(--brand-primary);
+  border-right: 2px solid var(--brand-accent);
 }
 
 [data-theme='dark'] .colPopular {
-  background: rgba(124, 92, 255, 0.1);
+  background: rgba(124, 92, 255, 0.13);
+}
+
+/* Keep the tint + side edges unbroken behind the grey group dividers */
+.groupRow td.colPopular {
+  background: rgba(124, 92, 255, 0.055);
+}
+
+[data-theme='dark'] .groupRow td.colPopular {
+  background: rgba(124, 92, 255, 0.13);
+}
+
+/* Header cap — the vivid violet → accent gradient. Its rounded top is drawn
+   by the ::before lip so the cap rises past the table's open top edge. */
+.compareTable thead th.colPopular {
+  background: linear-gradient(90deg, var(--brand-primary) 0%, var(--brand-accent) 100%);
+  border-bottom-color: transparent;
+}
+
+.compareTable thead th.colPopular::before {
+  content: '';
+  position: absolute;
+  left: -2px;
+  right: -2px;
+  top: -12px;
+  height: 14px;
+  background: linear-gradient(90deg, var(--brand-primary) 0%, var(--brand-accent) 100%);
+  border: 2px solid var(--brand-primary);
+  border-right-color: var(--brand-accent);
+  border-bottom: none;
+  border-radius: 14px 14px 0 0;
+}
+
+.compareTable thead th.colPopular .colHeadName {
+  color: #fff;
+  text-shadow:
+    0 1px 2px rgba(35, 10, 60, 0.55),
+    0 0 1px rgba(35, 10, 60, 0.5);
+}
+
+.compareTable thead th.colPopular .colHeadPrice {
+  color: #fff;
+  text-shadow:
+    0 1px 2px rgba(35, 10, 60, 0.5),
+    0 0 1px rgba(35, 10, 60, 0.45);
+}
+
+/* Rounded, colored foot closes the column card */
+.compareTable tbody tr:last-child td.colPopular {
+  border-bottom: 2px solid var(--brand-accent);
+  border-bottom-left-radius: 16px;
+  border-bottom-right-radius: 16px;
 }
 
 .groupRow td {
@@ -1100,6 +1159,41 @@
 
 [data-theme='dark'] .cellText {
   color: var(--neutral-300);
+}
+
+/* Feature label that links to a dedicated doc */
+.featureLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dashed var(--neutral-300);
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.featureLink:hover {
+  color: var(--brand-primary);
+  border-bottom-color: var(--brand-primary);
+}
+
+[data-theme='dark'] .featureLink {
+  border-bottom-color: var(--neutral-600);
+}
+
+[data-theme='dark'] .featureLink:hover {
+  color: var(--brand-primary-light);
+  border-bottom-color: var(--brand-primary-light);
+}
+
+.featureLink::after {
+  content: '↗';
+  font-size: 0.7em;
+  opacity: 0.55;
+}
+
+.featurePlain {
+  color: inherit;
 }
 
 /* ------------------------------------------------------- Steps */

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -35,16 +35,101 @@
   --ifm-color-primary-lightest: #5ec3fc;
 }
 
+/* GitHub star button: a small mascot reaching toward the bordered count pill. */
+.header-github {
+  display: inline-flex;
+  align-items: center;
+}
+
+.header-github__mascot {
+  display: flex;
+  line-height: 0;
+  /* Sit on top of the pill, overlapping its left edge; the 40px image is a
+     touch taller than the pill so it pokes past the button border. */
+  margin-right: -14px;
+  top: -3px;
+  position: relative;
+  z-index: 2;
+  transform-origin: bottom center;
+  animation: ducky-bob 3.2s ease-in-out infinite;
+}
+
+.header-github__mascot img {
+  height: auto;
+  display: block;
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.18));
+  transition: transform 220ms ease;
+}
+
+/* Hovering anywhere on the button makes the mascot lean in eagerly. */
+.header-github:hover .header-github__mascot img {
+  transform: scale(1.14) rotate(-5deg);
+}
+
+@keyframes ducky-bob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+/* Keep the navbar uncluttered on mobile; the pill still shows. */
+@media (max-width: 996px) {
+  .header-github__mascot {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header-github__mascot {
+    animation: none;
+  }
+}
+
+.header-github-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.7rem;
+  border: 2px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+  /* Opaque so the pill visibly covers the overlapped mascot edge. Matches the
+     navbar bg, so it still reads as a plain outlined pill. */
+  background-color: var(--ifm-navbar-background-color);
+  position: relative;
+  z-index: 1;
+  font-size: 0.85rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  color: var(--ifm-navbar-link-color);
+  transition:
+    border-color 180ms ease,
+    background-color 180ms ease,
+    transform 180ms ease;
+}
+
 /* https://github.com/facebook/jest/blob/main/website/src/css/docusaurusTheme.css */
 .header-github-link:hover {
-  opacity: 0.6;
+  opacity: 1;
+  border-color: var(--ifm-color-emphasis-500);
+  background-color: var(--ifm-color-emphasis-100);
+  color: var(--ifm-navbar-link-color);
+}
+
+.header-github-link:active {
+  transform: scale(0.97);
 }
 
 .header-github-link:before {
   content: '';
-  width: 24px;
-  height: 24px;
-  display: flex;
+  width: 18px;
+  height: 18px;
+  flex: none;
+  display: block;
   background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E")
     no-repeat;
 }
@@ -542,4 +627,30 @@ body.announcement-visible .navbar {
 .table-of-contents__link {
   position: relative;
   z-index: 1;
+}
+
+/* ===== Navbar dropdown toggle carets =====
+   Standard Docusaurus dropdowns (Docs / Ecosystem / About Us / language)
+   render a static CSS triangle caret. Replace it with the exact SVG chevron
+   used by the custom Products mega-menu (ProductsNavbarItem) and match its
+   0.25s rotate-on-open animation, so every navbar toggle is identical. */
+.navbar .dropdown > .navbar__link::after {
+  content: '';
+  display: inline-block;
+  width: 13px;
+  height: 13px;
+  margin-left: 4px;
+  border: none;
+  vertical-align: middle;
+  background-color: currentColor;
+  opacity: 0.7;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E") center / contain no-repeat;
+  transform: rotate(0);
+  transition: transform 0.25s ease;
+}
+
+.navbar .dropdown:hover > .navbar__link::after,
+.navbar .dropdown--show > .navbar__link::after {
+  transform: rotate(180deg);
 }

--- a/src/theme/Navbar/Content/GithubStars.js
+++ b/src/theme/Navbar/Content/GithubStars.js
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react'
+
+const REPO = 'tuya/TuyaOpen'
+const MASCOT_URL = 'https://images.tuyacn.com/fe-static/docs/img/7e618945-0ae2-4290-8844-6c33153e228a.png'
+// Shown on first paint (SSR + before the API responds) to avoid layout shift.
+const FALLBACK = '1.6k'
+const CACHE_KEY = 'tuyaopen-gh-stars'
+const CACHE_TTL = 6 * 60 * 60 * 1000 // 6h — avoid hammering the unauthenticated API
+
+function formatStars(n) {
+  if (n >= 1000) return `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k`
+  return String(n)
+}
+
+/**
+ * GitHub link in the navbar, rendered as a bordered pill showing the live star
+ * count. Rendering our own <a> (instead of a Docusaurus navbar item) keeps the
+ * external-link icon off and lets us update the count client-side.
+ */
+export default function GithubStars() {
+  const [stars, setStars] = useState(FALLBACK)
+  const href = `https://github.com/${REPO}`
+
+  useEffect(() => {
+    let cancelled = false
+
+    try {
+      const cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null')
+      if (cached && typeof cached.n === 'number' && Date.now() - cached.t < CACHE_TTL) {
+        setStars(formatStars(cached.n))
+        return undefined
+      }
+    } catch {
+      // ignore malformed cache
+    }
+
+    fetch(`https://api.github.com/repos/${REPO}`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((data) => {
+        if (cancelled || typeof data.stargazers_count !== 'number') return
+        setStars(formatStars(data.stargazers_count))
+        try {
+          localStorage.setItem(CACHE_KEY, JSON.stringify({ n: data.stargazers_count, t: Date.now() }))
+        } catch {
+          // storage may be unavailable (private mode) — the count still shows this session
+        }
+      })
+      .catch(() => {
+        // network / rate-limit failure: keep the fallback value
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="header-github">
+      {/* Decorative mascot — nudges people toward the star button. Duplicate of
+          the link below, so it's hidden from a11y/keyboard to avoid repetition. */}
+      <a
+        className="header-github__mascot"
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        tabIndex={-1}
+        aria-hidden="true"
+      >
+        <img src={MASCOT_URL} alt="" width={40} />
+      </a>
+      <a
+        className="header-github-link"
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`TuyaOpen on GitHub — ${stars} stars`}
+      >
+        {stars}
+      </a>
+    </div>
+  )
+}

--- a/src/theme/Navbar/Content/index.js
+++ b/src/theme/Navbar/Content/index.js
@@ -7,7 +7,6 @@
 import { useLocation } from '@docusaurus/router'
 import { ErrorCauseBoundary, ThemeClassNames, useThemeConfig } from '@docusaurus/theme-common'
 import { splitNavbarItems, useNavbarMobileSidebar } from '@docusaurus/theme-common/internal'
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle'
 import NavbarLogo from '@theme/Navbar/Logo'
 import NavbarMobileSidebarToggle from '@theme/Navbar/MobileSidebar/Toggle'
@@ -17,6 +16,7 @@ import SearchBar from '@theme/SearchBar'
 import clsx from 'clsx'
 import React from 'react'
 
+import GithubStars from './GithubStars'
 import styles from './styles.module.css'
 
 function useNavbarItems() {
@@ -58,12 +58,10 @@ function NavbarContentLayout({ left, right }) {
 
 export default function NavbarContent() {
   const mobileSidebar = useNavbarMobileSidebar()
-  const { i18n } = useDocusaurusContext()
   const { pathname } = useLocation()
   const items = useNavbarItems()
   const [leftItems, rightItems] = splitNavbarItems(items)
   const searchBarItem = items.find((item) => item.type === 'search')
-  const showEventRegistration = i18n.currentLocale === 'zh'
   // Append an "IDE" wordmark after the logo on the TuyaOpen IDE product page.
   const isIdePage = pathname.replace(/\/$/, '').endsWith('/tuyaopen-ide')
 
@@ -75,19 +73,12 @@ export default function NavbarContent() {
           <NavbarLogo />
           {isIdePage && <span className={styles.productTag}>IDE</span>}
           <NavbarItems items={leftItems} />
-          {showEventRegistration && (
-            <NavbarItem
-              href="https://images.tuyacn.com/rms-static/fe11d250-54e9-11f1-8d53-258e63d3fe0e-1779349939189.html?tyName=event-registration.html"
-              label="活动报名"
-              target="_blank"
-              rel="noopener noreferrer"
-            />
-          )}
         </>
       }
       right={
         <>
           <NavbarItems items={rightItems} />
+          <GithubStars />
           <NavbarColorModeToggle className={styles.colorModeToggle} />
           {!searchBarItem && (
             <NavbarSearch>


### PR DESCRIPTION
## Summary

Theme/site refinements on the navbar, footer, and a few pages.

### Navbar
- **GitHub star button**: replaces the old icon-only GitHub link with a bordered pill showing the **live star count** for `tuya/TuyaOpen` (fetched from the GitHub API, formatted `1615 → 1.6k`, cached 6h in `localStorage`, `1.6k` fallback on first paint / rate-limit). The **ducky mascot** (Tuya CDN asset) perches on top of the button with an idle float + hover lean-in. No external-link icon.
- **Ecosystem dropdown**: groups Projects / Blog / Event Registration.

### Footer
- New **Legal** section (Terms of Service, Legal Statement, Privacy Policy, CA Privacy Notice).
- Apache license linked in the copyright line.

### Pages / i18n
- `pricing.js` / `pricing.module.css`, `about-us.module.css`, IDE copy (`tuyaOpenIdeCopy.js`), and zh `footer.json` / `navbar.json` updates.

## Notes
- Mascot is served from the Tuya CDN (`images.tuyacn.com/...`), not committed to `static/`.
- `tools/TuyaOpen-WebTools/` (a nested git repo in the working tree) is intentionally **not** part of this PR.
- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)