### PR TITLE
feat(tutorials): filterable Tutorials hub with sidebar nav, glow cards & license guides

### DIFF
--- a/docs/tutorials/_sample-getting-started.md
+++ b/docs/tutorials/_sample-getting-started.md
@@ -1,0 +1,44 @@
+Welcome! This file is a **Markdown partial** (its name starts with `_`, so
+Docusaurus does not turn it into a standalone doc page). The
+`/tutorials/markdown-template` page imports it and renders it inside the shared
+tutorial shell, so it picks up the same styling as the interactive tutorials.
+
+## What you get for free
+
+Because the shell applies the shared `markdown` body styles, ordinary Markdown
+just works and stays consistent with the hand-built pages:
+
+- Headings, paragraphs, and lists
+- Links, like the [TuyaOpen repository](https://github.com/tuya/TuyaOpen)
+- Inline `code` and fenced code blocks
+- Tables, blockquotes, and images
+
+## A code block
+
+```bash
+# Clone and build your first firmware
+git clone https://github.com/tuya/TuyaOpen
+cd TuyaOpen
+. ./export.sh
+tos build
+```
+
+## A small table
+
+| Chip     | Wireless        | Notes                    |
+| -------- | --------------- | ------------------------ |
+| T5AI     | Wi-Fi + BLE     | Flagship AI dev board    |
+| BK7231N  | Wi-Fi + BLE     | Low-cost combo           |
+| ESP32    | Wi-Fi + BLE     | Widely available         |
+
+> **Tip:** Keep tutorial prose task-focused. Lead with what the reader will do,
+> then show the exact commands.
+
+## Next steps
+
+1. Copy this file to `docs/tutorials/_your-tutorial.md`.
+2. Point a page at it (see `src/pages/tutorials/markdown-template.jsx`).
+3. Register it in `src/data/tutorials.js` with `kind: 'markdown'`.
+
+When you're done, the card appears on the [Tutorials hub](/tutorials) under the
+category you assigned it.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -148,6 +148,11 @@ const config = {
           ],
         },
         {
+          label: 'Tutorials',
+          to: '/tutorials',
+          position: 'left',
+        },
+        {
           type: 'dropdown',
           label: 'Ecosystem',
           position: 'left',

--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -10,5 +10,9 @@
   "item.label.Projects": {
     "message": "Projects",
     "description": "Navbar item with label Projects"
+  },
+  "item.label.Tutorials": {
+    "message": "Tutorials",
+    "description": "Navbar item with label Tutorials"
   }
 } 

--- a/i18n/zh/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh/docusaurus-theme-classic/navbar.json
@@ -59,6 +59,10 @@
     "message": "项目",
     "description": "Navbar item with label Projects"
   },
+  "item.label.Tutorials": {
+    "message": "教程",
+    "description": "Navbar item with label Tutorials"
+  },
   "item.label.Ecosystem": {
     "message": "生态",
     "description": "Navbar dropdown with label Ecosystem"

--- a/src/components/BorderGlow/BorderGlow.css
+++ b/src/components/BorderGlow/BorderGlow.css
@@ -1,0 +1,141 @@
+.border-glow-card {
+  --edge-proximity: 0;
+  --cursor-angle: 45deg;
+  --edge-sensitivity: 30;
+  --color-sensitivity: calc(var(--edge-sensitivity) + 20);
+  --border-radius: 28px;
+  --glow-padding: 40px;
+  --cone-spread: 25;
+
+  position: relative;
+  border-radius: var(--border-radius);
+  isolation: isolate;
+  transform: translate3d(0, 0, 0.01px);
+  display: grid;
+  border: 1px solid rgb(255 255 255 / 15%);
+  background: var(--card-bg, #120F17);
+  overflow: visible;
+  box-shadow:
+    rgba(0, 0, 0, 0.1) 0px 1px 2px,
+    rgba(0, 0, 0, 0.1) 0px 2px 4px,
+    rgba(0, 0, 0, 0.1) 0px 4px 8px,
+    rgba(0, 0, 0, 0.1) 0px 8px 16px,
+    rgba(0, 0, 0, 0.1) 0px 16px 32px,
+    rgba(0, 0, 0, 0.1) 0px 32px 64px;
+}
+
+.border-glow-card::before,
+.border-glow-card::after,
+.border-glow-card > .edge-light {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  transition: opacity 0.25s ease-out;
+  z-index: -1;
+}
+
+.border-glow-card:not(:hover):not(.sweep-active)::before,
+.border-glow-card:not(:hover):not(.sweep-active)::after,
+.border-glow-card:not(:hover):not(.sweep-active) > .edge-light {
+  opacity: 0;
+  transition: opacity 0.75s ease-in-out;
+}
+
+/* colored mesh-gradient border */
+.border-glow-card::before {
+  border: 1px solid transparent;
+  background:
+    linear-gradient(var(--card-bg, #120F17) 0 100%) padding-box,
+    linear-gradient(rgb(255 255 255 / 0%) 0% 100%) border-box,
+    var(--gradient-one, radial-gradient(at 80% 55%, hsla(268, 100%, 76%, 1) 0px, transparent 50%)) border-box,
+    var(--gradient-two, radial-gradient(at 69% 34%, hsla(349, 100%, 74%, 1) 0px, transparent 50%)) border-box,
+    var(--gradient-three, radial-gradient(at 8% 6%, hsla(136, 100%, 78%, 1) 0px, transparent 50%)) border-box,
+    var(--gradient-four, radial-gradient(at 41% 38%, hsla(192, 100%, 64%, 1) 0px, transparent 50%)) border-box,
+    var(--gradient-five, radial-gradient(at 86% 85%, hsla(186, 100%, 74%, 1) 0px, transparent 50%)) border-box,
+    var(--gradient-six, radial-gradient(at 82% 18%, hsla(52, 100%, 65%, 1) 0px, transparent 50%)) border-box,
+    var(--gradient-seven, radial-gradient(at 51% 4%, hsla(12, 100%, 72%, 1) 0px, transparent 50%)) border-box,
+    var(--gradient-base, linear-gradient(#c299ff 0 100%)) border-box;
+
+  opacity: calc((var(--edge-proximity) - var(--color-sensitivity)) / (100 - var(--color-sensitivity)));
+
+  mask-image:
+    conic-gradient(
+      from var(--cursor-angle) at center,
+      black calc(var(--cone-spread) * 1%),
+      transparent calc((var(--cone-spread) + 15) * 1%),
+      transparent calc((100 - var(--cone-spread) - 15) * 1%),
+      black calc((100 - var(--cone-spread)) * 1%)
+    );
+}
+
+/* colored mesh-gradient background fill near edges */
+.border-glow-card::after {
+  border: 1px solid transparent;
+  background:
+    var(--gradient-one, radial-gradient(at 80% 55%, hsla(268, 100%, 76%, 1) 0px, transparent 50%)) padding-box,
+    var(--gradient-two, radial-gradient(at 69% 34%, hsla(349, 100%, 74%, 1) 0px, transparent 50%)) padding-box,
+    var(--gradient-three, radial-gradient(at 8% 6%, hsla(136, 100%, 78%, 1) 0px, transparent 50%)) padding-box,
+    var(--gradient-four, radial-gradient(at 41% 38%, hsla(192, 100%, 64%, 1) 0px, transparent 50%)) padding-box,
+    var(--gradient-five, radial-gradient(at 86% 85%, hsla(186, 100%, 74%, 1) 0px, transparent 50%)) padding-box,
+    var(--gradient-six, radial-gradient(at 82% 18%, hsla(52, 100%, 65%, 1) 0px, transparent 50%)) padding-box,
+    var(--gradient-seven, radial-gradient(at 51% 4%, hsla(12, 100%, 72%, 1) 0px, transparent 50%)) padding-box,
+    var(--gradient-base, linear-gradient(#c299ff 0 100%)) padding-box;
+
+  mask-image:
+    linear-gradient(to bottom, black, black),
+    radial-gradient(ellipse at 50% 50%, black 40%, transparent 65%),
+    radial-gradient(ellipse at 66% 66%, black 5%, transparent 40%),
+    radial-gradient(ellipse at 33% 33%, black 5%, transparent 40%),
+    radial-gradient(ellipse at 66% 33%, black 5%, transparent 40%),
+    radial-gradient(ellipse at 33% 66%, black 5%, transparent 40%),
+    conic-gradient(from var(--cursor-angle) at center, transparent 5%, black 15%, black 85%, transparent 95%);
+
+  mask-composite: subtract, add, add, add, add, add;
+  opacity: calc(var(--fill-opacity, 0.5) * (var(--edge-proximity) - var(--color-sensitivity)) / (100 - var(--color-sensitivity)));
+  mix-blend-mode: soft-light;
+}
+
+/* outer glow layer */
+.border-glow-card > .edge-light {
+  inset: calc(var(--glow-padding) * -1);
+  pointer-events: none;
+  z-index: 1;
+
+  mask-image:
+    conic-gradient(
+      from var(--cursor-angle) at center, black 2.5%, transparent 10%, transparent 90%, black 97.5%
+    );
+
+  opacity: calc((var(--edge-proximity) - var(--edge-sensitivity)) / (100 - var(--edge-sensitivity)));
+  mix-blend-mode: plus-lighter;
+}
+
+.border-glow-card > .edge-light::before {
+  content: "";
+  position: absolute;
+  inset: var(--glow-padding);
+  border-radius: inherit;
+  box-shadow:
+    inset 0 0 0 1px var(--glow-color, hsl(40deg 80% 80% / 100%)),
+    inset 0 0 1px 0 var(--glow-color-60, hsl(40deg 80% 80% / 60%)),
+    inset 0 0 3px 0 var(--glow-color-50, hsl(40deg 80% 80% / 50%)),
+    inset 0 0 6px 0 var(--glow-color-40, hsl(40deg 80% 80% / 40%)),
+    inset 0 0 15px 0 var(--glow-color-30, hsl(40deg 80% 80% / 30%)),
+    inset 0 0 25px 2px var(--glow-color-20, hsl(40deg 80% 80% / 20%)),
+    inset 0 0 50px 2px var(--glow-color-10, hsl(40deg 80% 80% / 10%)),
+    0 0 1px 0 var(--glow-color-60, hsl(40deg 80% 80% / 60%)),
+    0 0 3px 0 var(--glow-color-50, hsl(40deg 80% 80% / 50%)),
+    0 0 6px 0 var(--glow-color-40, hsl(40deg 80% 80% / 40%)),
+    0 0 15px 0 var(--glow-color-30, hsl(40deg 80% 80% / 30%)),
+    0 0 25px 2px var(--glow-color-20, hsl(40deg 80% 80% / 20%)),
+    0 0 50px 2px var(--glow-color-10, hsl(40deg 80% 80% / 10%));
+}
+
+.border-glow-inner {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: auto;
+  z-index: 1;
+}

--- a/src/components/BorderGlow/index.jsx
+++ b/src/components/BorderGlow/index.jsx
@@ -1,0 +1,159 @@
+import { useRef, useCallback, useEffect } from 'react';
+import './BorderGlow.css';
+
+function parseHSL(hslStr) {
+  const match = hslStr.match(/([\d.]+)\s*([\d.]+)%?\s*([\d.]+)%?/);
+  if (!match) return { h: 40, s: 80, l: 80 };
+  return { h: parseFloat(match[1]), s: parseFloat(match[2]), l: parseFloat(match[3]) };
+}
+
+function buildGlowVars(glowColor, intensity) {
+  const { h, s, l } = parseHSL(glowColor);
+  const base = `${h}deg ${s}% ${l}%`;
+  const opacities = [100, 60, 50, 40, 30, 20, 10];
+  const keys = ['', '-60', '-50', '-40', '-30', '-20', '-10'];
+  const vars = {};
+  for (let i = 0; i < opacities.length; i++) {
+    vars[`--glow-color${keys[i]}`] = `hsl(${base} / ${Math.min(opacities[i] * intensity, 100)}%)`;
+  }
+  return vars;
+}
+
+const GRADIENT_POSITIONS = ['80% 55%', '69% 34%', '8% 6%', '41% 38%', '86% 85%', '82% 18%', '51% 4%'];
+const GRADIENT_KEYS = ['--gradient-one', '--gradient-two', '--gradient-three', '--gradient-four', '--gradient-five', '--gradient-six', '--gradient-seven'];
+const COLOR_MAP = [0, 1, 2, 0, 1, 2, 1];
+
+function buildGradientVars(colors) {
+  const vars = {};
+  for (let i = 0; i < 7; i++) {
+    const c = colors[Math.min(COLOR_MAP[i], colors.length - 1)];
+    vars[GRADIENT_KEYS[i]] = `radial-gradient(at ${GRADIENT_POSITIONS[i]}, ${c} 0px, transparent 50%)`;
+  }
+  vars['--gradient-base'] = `linear-gradient(${colors[0]} 0 100%)`;
+  return vars;
+}
+
+function easeOutCubic(x) { return 1 - Math.pow(1 - x, 3); }
+function easeInCubic(x) { return x * x * x; }
+
+function animateValue({ start = 0, end = 100, duration = 1000, delay = 0, ease = easeOutCubic, onUpdate, onEnd }) {
+  const t0 = performance.now() + delay;
+  function tick() {
+    const elapsed = performance.now() - t0;
+    const t = Math.min(elapsed / duration, 1);
+    onUpdate(start + (end - start) * ease(t));
+    if (t < 1) requestAnimationFrame(tick);
+    else if (onEnd) onEnd();
+  }
+  setTimeout(() => requestAnimationFrame(tick), delay);
+}
+
+const BorderGlow = ({
+  children,
+  className = '',
+  edgeSensitivity = 30,
+  glowColor = '40 80 80',
+  backgroundColor = '#120F17',
+  borderRadius = 28,
+  glowRadius = 40,
+  glowIntensity = 1.0,
+  coneSpread = 25,
+  animated = false,
+  colors = ['#c084fc', '#f472b6', '#38bdf8'],
+  fillOpacity = 0.5,
+}) => {
+  const cardRef = useRef(null);
+
+  const getCenterOfElement = useCallback((el) => {
+    const { width, height } = el.getBoundingClientRect();
+    return [width / 2, height / 2];
+  }, []);
+
+  const getEdgeProximity = useCallback((el, x, y) => {
+    const [cx, cy] = getCenterOfElement(el);
+    const dx = x - cx;
+    const dy = y - cy;
+    let kx = Infinity;
+    let ky = Infinity;
+    if (dx !== 0) kx = cx / Math.abs(dx);
+    if (dy !== 0) ky = cy / Math.abs(dy);
+    return Math.min(Math.max(1 / Math.min(kx, ky), 0), 1);
+  }, [getCenterOfElement]);
+
+  const getCursorAngle = useCallback((el, x, y) => {
+    const [cx, cy] = getCenterOfElement(el);
+    const dx = x - cx;
+    const dy = y - cy;
+    if (dx === 0 && dy === 0) return 0;
+    const radians = Math.atan2(dy, dx);
+    let degrees = radians * (180 / Math.PI) + 90;
+    if (degrees < 0) degrees += 360;
+    return degrees;
+  }, [getCenterOfElement]);
+
+  const handlePointerMove = useCallback((e) => {
+    const card = cardRef.current;
+    if (!card) return;
+
+    const rect = card.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const edge = getEdgeProximity(card, x, y);
+    const angle = getCursorAngle(card, x, y);
+
+    card.style.setProperty('--edge-proximity', `${(edge * 100).toFixed(3)}`);
+    card.style.setProperty('--cursor-angle', `${angle.toFixed(3)}deg`);
+  }, [getEdgeProximity, getCursorAngle]);
+
+  useEffect(() => {
+    if (!animated || !cardRef.current) return;
+    // Respect users who prefer reduced motion — skip the intro sweep.
+    if (typeof window !== 'undefined' && window.matchMedia
+        && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const card = cardRef.current;
+    const angleStart = 110;
+    const angleEnd = 465;
+    card.classList.add('sweep-active');
+    card.style.setProperty('--cursor-angle', `${angleStart}deg`);
+
+    animateValue({ duration: 500, onUpdate: v => card.style.setProperty('--edge-proximity', v) });
+    animateValue({ ease: easeInCubic, duration: 1500, end: 50, onUpdate: v => {
+      card.style.setProperty('--cursor-angle', `${(angleEnd - angleStart) * (v / 100) + angleStart}deg`);
+    }});
+    animateValue({ ease: easeOutCubic, delay: 1500, duration: 2250, start: 50, end: 100, onUpdate: v => {
+      card.style.setProperty('--cursor-angle', `${(angleEnd - angleStart) * (v / 100) + angleStart}deg`);
+    }});
+    animateValue({ ease: easeInCubic, delay: 2500, duration: 1500, start: 100, end: 0,
+      onUpdate: v => card.style.setProperty('--edge-proximity', v),
+      onEnd: () => card.classList.remove('sweep-active'),
+    });
+  }, [animated]);
+
+  const glowVars = buildGlowVars(glowColor, glowIntensity);
+
+  return (
+    <div
+      ref={cardRef}
+      onPointerMove={handlePointerMove}
+      className={`border-glow-card ${className}`}
+      style={{
+        '--card-bg': backgroundColor,
+        '--edge-sensitivity': edgeSensitivity,
+        '--border-radius': `${borderRadius}px`,
+        '--glow-padding': `${glowRadius}px`,
+        '--cone-spread': coneSpread,
+        '--fill-opacity': fillOpacity,
+        ...glowVars,
+        ...buildGradientVars(colors),
+      }}
+    >
+      <span className="edge-light" />
+      <div className="border-glow-inner">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default BorderGlow;

--- a/src/components/FlowingMenu/FlowingMenu.css
+++ b/src/components/FlowingMenu/FlowingMenu.css
@@ -1,0 +1,179 @@
+/* =========================================================================
+ * FlowingMenu — sidebar-tuned (category filter). Class names kept distinct
+ * (flowmenu / flowmarquee) so they don't collide with anything else.
+ * ========================================================================= */
+.flowmenu {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border: 1px solid var(--flow-border, rgba(148, 163, 184, 0.2));
+  border-radius: 14px;
+  overflow: hidden;
+  background: transparent;
+}
+
+.flowmenu__item {
+  position: relative;
+  overflow: hidden;
+  border-top: 1px solid var(--flow-border, rgba(148, 163, 184, 0.2));
+}
+
+.flowmenu__item:first-child {
+  border-top: none;
+}
+
+/* Active accent bar on the left edge. */
+.flowmenu__item--active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(180deg, var(--ifm-color-primary), #ff6b35);
+  z-index: 3;
+}
+
+.flowmenu__link {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  min-height: 58px;
+  padding: 0 1.15rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-align: left;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.flowmenu__link:hover {
+  background: rgba(124, 92, 255, 0.06);
+}
+
+.flowmenu__item--active .flowmenu__link {
+  color: var(--ifm-color-primary) !important;
+  font-weight: 700;
+}
+
+.flowmenu__label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.flowmenu__count {
+  flex-shrink: 0;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--ifm-color-emphasis-600);
+  background: var(--ifm-color-emphasis-200);
+}
+
+.flowmenu__item--active .flowmenu__count {
+  color: #fff;
+  background: var(--ifm-color-primary);
+}
+
+/* -------------------------------------------------------------- Marquee */
+.flowmarquee {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  transform: translate3d(0, 101%, 0);
+  z-index: 2;
+}
+
+.flowmarquee__wrap {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.flowmarquee__inner {
+  display: flex;
+  align-items: center;
+  position: relative;
+  height: 100%;
+  width: fit-content;
+  will-change: transform;
+}
+
+.flowmarquee__part {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  font-weight: 700;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.flowmarquee__part span:first-child {
+  white-space: nowrap;
+  padding: 0 0.9rem;
+}
+
+.flowmarquee__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  opacity: 0.7;
+}
+
+/* Respect reduced-motion: no marquee sweep intent, keep it static/hidden. */
+@media (prefers-reduced-motion: reduce) {
+  .flowmarquee {
+    display: none;
+  }
+}
+
+/* -------------------------------------------------- Mobile: horizontal row */
+@media (max-width: 996px) {
+  .flowmenu {
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .flowmenu::-webkit-scrollbar {
+    display: none;
+  }
+  .flowmenu__item {
+    border-top: none;
+    border-left: 1px solid var(--flow-border, rgba(148, 163, 184, 0.2));
+    flex: 0 0 auto;
+  }
+  .flowmenu__item:first-child {
+    border-left: none;
+  }
+  .flowmenu__item--active::before {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: auto;
+    height: 3px;
+    background: linear-gradient(90deg, var(--ifm-color-primary), #ff6b35);
+  }
+  .flowmenu__link {
+    min-height: 46px;
+    font-size: 0.88rem;
+    white-space: nowrap;
+  }
+}

--- a/src/components/FlowingMenu/index.jsx
+++ b/src/components/FlowingMenu/index.jsx
@@ -1,0 +1,141 @@
+import React, { useRef, useEffect, useState } from 'react';
+import { gsap } from 'gsap';
+import { clsx } from 'clsx';
+import './FlowingMenu.css';
+
+/* =========================================================================
+ * FlowingMenu (React Bits) — adapted for category FILTERING.
+ * -------------------------------------------------------------------------
+ * Instead of navigating (<a href>), each item is a <button> that calls
+ * onSelect(key). Keeps the signature GSAP marquee-sweep on hover, adds an
+ * active state + count badge, and is theme-aware (light/dark) via site tokens.
+ *
+ * items: [{ key, text, count }]
+ * ========================================================================= */
+export default function FlowingMenu({
+  items = [],
+  activeKey,
+  onSelect,
+  speed = 12,
+  textColor = 'var(--ifm-color-emphasis-800)',
+  marqueeBgColor = '#7c5cff',
+  marqueeTextColor = '#ffffff',
+  borderColor = 'var(--ifm-toc-border-color)',
+}) {
+  return (
+    <nav className="flowmenu" style={{ '--flow-border': borderColor }}>
+      {items.map((item) => (
+        <MenuItem
+          key={item.key}
+          itemKey={item.key}
+          text={item.text}
+          count={item.count}
+          active={item.key === activeKey}
+          onSelect={onSelect}
+          speed={speed}
+          textColor={textColor}
+          marqueeBgColor={marqueeBgColor}
+          marqueeTextColor={marqueeTextColor}
+        />
+      ))}
+    </nav>
+  );
+}
+
+function MenuItem({ itemKey, text, count, active, onSelect, speed, textColor, marqueeBgColor, marqueeTextColor }) {
+  const itemRef = useRef(null);
+  const marqueeRef = useRef(null);
+  const marqueeInnerRef = useRef(null);
+  const animationRef = useRef(null);
+  const [repetitions, setRepetitions] = useState(6);
+
+  const animationDefaults = { duration: 0.6, ease: 'expo' };
+
+  const distMetric = (x, y, x2, y2) => {
+    const xDiff = x - x2;
+    const yDiff = y - y2;
+    return xDiff * xDiff + yDiff * yDiff;
+  };
+
+  const findClosestEdge = (mouseX, mouseY, width, height) => {
+    const topEdgeDist = distMetric(mouseX, mouseY, width / 2, 0);
+    const bottomEdgeDist = distMetric(mouseX, mouseY, width / 2, height);
+    return topEdgeDist < bottomEdgeDist ? 'top' : 'bottom';
+  };
+
+  // Enough copies of the label to fill the row width for a seamless loop.
+  useEffect(() => {
+    const calc = () => {
+      const part = marqueeInnerRef.current?.querySelector('.flowmarquee__part');
+      const row = itemRef.current;
+      if (!part || !row) return;
+      const contentWidth = part.offsetWidth || 1;
+      const needed = Math.ceil((row.offsetWidth || window.innerWidth) / contentWidth) + 2;
+      setRepetitions(Math.max(6, needed));
+    };
+    calc();
+    window.addEventListener('resize', calc);
+    return () => window.removeEventListener('resize', calc);
+  }, [text]);
+
+  useEffect(() => {
+    const setup = () => {
+      const inner = marqueeInnerRef.current;
+      const part = inner?.querySelector('.flowmarquee__part');
+      if (!inner || !part) return;
+      const contentWidth = part.offsetWidth;
+      if (!contentWidth) return;
+      if (animationRef.current) animationRef.current.kill();
+      animationRef.current = gsap.to(inner, { x: -contentWidth, duration: speed, ease: 'none', repeat: -1 });
+    };
+    const timer = setTimeout(setup, 50);
+    return () => {
+      clearTimeout(timer);
+      if (animationRef.current) animationRef.current.kill();
+    };
+  }, [text, repetitions, speed]);
+
+  const sweep = (ev, entering) => {
+    if (!itemRef.current || !marqueeRef.current || !marqueeInnerRef.current) return;
+    const rect = itemRef.current.getBoundingClientRect();
+    const edge = findClosestEdge(ev.clientX - rect.left, ev.clientY - rect.top, rect.width, rect.height);
+    const tl = gsap.timeline({ defaults: animationDefaults });
+    if (entering) {
+      tl.set(marqueeRef.current, { y: edge === 'top' ? '-101%' : '101%' }, 0)
+        .set(marqueeInnerRef.current, { y: edge === 'top' ? '101%' : '-101%' }, 0)
+        .to([marqueeRef.current, marqueeInnerRef.current], { y: '0%' }, 0);
+    } else {
+      tl.to(marqueeRef.current, { y: edge === 'top' ? '-101%' : '101%' }, 0)
+        .to(marqueeInnerRef.current, { y: edge === 'top' ? '101%' : '-101%' }, 0);
+    }
+  };
+
+  return (
+    <div className={clsx('flowmenu__item', active && 'flowmenu__item--active')} ref={itemRef}>
+      <button
+        type="button"
+        className="flowmenu__link"
+        onClick={() => onSelect(itemKey)}
+        onMouseEnter={(e) => sweep(e, true)}
+        onMouseLeave={(e) => sweep(e, false)}
+        aria-pressed={active}
+        style={{ color: textColor }}
+      >
+        <span className="flowmenu__label">{text}</span>
+        {typeof count === 'number' && <span className="flowmenu__count">{count}</span>}
+      </button>
+      <div className="flowmarquee" ref={marqueeRef} style={{ backgroundColor: marqueeBgColor }}>
+        <div className="flowmarquee__wrap">
+          <div className="flowmarquee__inner" ref={marqueeInnerRef} aria-hidden="true">
+            {[...Array(repetitions)].map((_, idx) => (
+              <div className="flowmarquee__part" key={idx} style={{ color: marqueeTextColor }}>
+                <span>{text}</span>
+                <span className="flowmarquee__dot" style={{ background: marqueeTextColor }} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TutorialShell/index.jsx
+++ b/src/components/TutorialShell/index.jsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { clsx } from 'clsx';
+import styles from './styles.module.css';
+
+/* =========================================================================
+ * TutorialShell — shared chrome for every tutorial detail page.
+ * -------------------------------------------------------------------------
+ * Wrap either hand-built React content OR rendered Markdown in this shell and
+ * both come out looking identical: same hero, same sticky contents, same body
+ * typography. That is what keeps `kind: 'interactive'` and `kind: 'markdown'`
+ * tutorials consistent.
+ *
+ * Props:
+ *   badge     small pill above the title (usually the category label)
+ *   title     page H1
+ *   subtitle  one-line intro under the title
+ *   meta      optional array of strings shown as pills (e.g. ['Beginner', '10 min'])
+ *   nav       optional [{ id, label }] — renders a sticky "On this page" TOC that
+ *             tracks <section id="…"> elements in the content. Omit for no TOC.
+ *   markdown  when true, the content column gets the `.markdown` body styles so
+ *             rendered MDX matches the hand-built pages. (interactive pages that
+ *             use the shell's own classes should leave this false.)
+ *   docTitle / docDescription  <head> values (default to title / subtitle)
+ *   children  the tutorial content
+ * ========================================================================= */
+export default function TutorialShell({
+  badge,
+  title,
+  subtitle,
+  meta = [],
+  nav = null,
+  markdown = false,
+  docTitle,
+  docDescription,
+  children,
+}) {
+  const { i18n } = useDocusaurusContext();
+  const locale = i18n.currentLocale === 'zh' ? 'zh' : 'en';
+  const hubHref = locale === 'zh' ? '/zh/tutorials' : '/tutorials';
+  const backLabel = locale === 'zh' ? '← 返回教程' : '← Back to tutorials';
+  const tocLabel = locale === 'zh' ? '本页内容' : 'On this page';
+
+  const hasToc = Array.isArray(nav) && nav.length > 0;
+  const [activeId, setActiveId] = useState(hasToc ? nav[0].id : null);
+  const contentRef = useRef(null);
+  const tocListRef = useRef(null);
+
+  // Reading-progress TOC — mirrors the docs TOC behaviour (src/clientModules/
+  // toc-reading-progress.js): a primary-colored fill on the rail tracks how far
+  // the reader has scrolled, and the active item is the last section whose top
+  // has passed a reading line just below the sticky navbar. Window is the
+  // scroller on this site, so a rAF-throttled scroll listener drives both.
+  useEffect(() => {
+    if (!hasToc || typeof window === 'undefined') return undefined;
+    const root = contentRef.current;
+    if (!root) return undefined;
+    const sections = Array.from(root.querySelectorAll('section[id]'));
+    if (!sections.length) return undefined;
+
+    const readingLine = () => {
+      const navbar = document.querySelector('.navbar');
+      return (navbar ? navbar.offsetHeight : 60) + 40;
+    };
+
+    let ticking = false;
+
+    const update = () => {
+      ticking = false;
+      const scrollY = window.scrollY || window.pageYOffset || 0;
+      const readingPos = scrollY + readingLine();
+      const tops = sections.map((s) => s.getBoundingClientRect().top + scrollY);
+
+      let current = -1;
+      for (let i = 0; i < tops.length; i += 1) {
+        if (tops[i] <= readingPos) current = i;
+        else break;
+      }
+      const atBottom =
+        window.innerHeight + scrollY >= document.documentElement.scrollHeight - 2;
+      if (atBottom) current = sections.length - 1;
+
+      setActiveId(current >= 0 ? sections[current].id : sections[0].id);
+
+      // Map the reading position onto the TOC link offsets for the fill height.
+      const ul = tocListRef.current;
+      if (ul) {
+        const links = ul.querySelectorAll('a[href^="#"]');
+        let fillPx = 0;
+        if (current >= 0 && links[current]) {
+          const linkTop = links[current].offsetTop;
+          const nextTop =
+            current + 1 < links.length ? links[current + 1].offsetTop : ul.scrollHeight;
+          const secStart = tops[current];
+          const secEnd = current + 1 < tops.length ? tops[current + 1] : scrollY + document.documentElement.scrollHeight;
+          let frac = secEnd > secStart ? (readingPos - secStart) / (secEnd - secStart) : 1;
+          frac = Math.max(0, Math.min(1, frac));
+          fillPx = linkTop + frac * (nextTop - linkTop);
+        }
+        if (atBottom) fillPx = ul.scrollHeight;
+        ul.style.setProperty('--toc-progress', `${Math.round(fillPx)}px`);
+      }
+    };
+
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(update);
+    };
+
+    update();
+    const timers = [setTimeout(update, 250), setTimeout(update, 1000)];
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+      timers.forEach(clearTimeout);
+    };
+  }, [hasToc, locale]);
+
+  return (
+    <Layout title={docTitle || title} description={docDescription || subtitle}>
+      <main className={styles.root}>
+        {/* -------------------------------------------------------- Hero */}
+        <header className={styles.hero}>
+          <div className={styles.heroGlow} aria-hidden />
+          <div className={styles.heroInner}>
+            <Link to={hubHref} className={styles.breadcrumb}>
+              {backLabel}
+            </Link>
+            {badge && <span className={styles.heroBadge}>{badge}</span>}
+            <h1 className={styles.heroTitle}>{title}</h1>
+            {subtitle && <p className={styles.heroSubtitle}>{subtitle}</p>}
+            {meta.length > 0 && (
+              <div className={styles.heroMeta}>
+                {meta.map((m) => (
+                  <span key={m} className={styles.metaPill}>
+                    {m}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </header>
+
+        <div className={clsx(styles.layout, !hasToc && styles.layoutNoToc)}>
+          {/* ----------------------------------------------------- TOC */}
+          {hasToc && (
+            <aside className={styles.toc}>
+              <div className={styles.tocSticky}>
+                <div className={styles.tocTitle}>{tocLabel}</div>
+                <nav>
+                  <ul ref={tocListRef}>
+                    {nav.map((item) => (
+                      <li key={item.id}>
+                        <a
+                          href={`#${item.id}`}
+                          className={clsx(styles.tocLink, activeId === item.id && styles.tocLinkActive)}
+                        >
+                          {item.label}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
+              </div>
+            </aside>
+          )}
+
+          {/* ------------------------------------------------- Content */}
+          <div className={clsx(styles.content, markdown && styles.markdown)} ref={contentRef}>
+            {children}
+          </div>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/src/components/TutorialShell/styles.module.css
+++ b/src/components/TutorialShell/styles.module.css
@@ -1,6 +1,9 @@
-/* ----------------------------------------------------------------------- */
-/* tyutool help guide — shares the landing design language                  */
-/* ----------------------------------------------------------------------- */
+/* =========================================================================
+ * TutorialShell — shared design language for tutorial detail pages.
+ * Mirrors the tyutool guide look so every tutorial (markdown or interactive)
+ * is consistent. Interactive pages use the exported helper classes below;
+ * markdown pages get the same look via the `.markdown` element selectors.
+ * ========================================================================= */
 
 .root {
   --brand-primary: #7c5cff;
@@ -18,9 +21,9 @@
   --neutral-800: #1e293b;
   --neutral-900: #0f172a;
 
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   color: var(--neutral-900);
-  /* clip (not hidden) so the sticky TOC isn't trapped in a scroll container. */
+  /* clip (not hidden): prevents horizontal overflow WITHOUT turning .root into
+   * a scroll container, so the sticky TOC keeps sticking to the viewport. */
   overflow-x: clip;
 }
 
@@ -107,6 +110,25 @@
   margin: 0;
 }
 
+.heroMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+}
+
+.metaPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+}
+
 /* ---------------------------------------------------------- Layout */
 .layout {
   max-width: 1180px;
@@ -121,6 +143,10 @@
   .layout {
     grid-template-columns: 220px 1fr;
     gap: 3rem;
+  }
+  .layoutNoToc {
+    grid-template-columns: 1fr;
+    max-width: 820px;
   }
 }
 
@@ -153,22 +179,51 @@
   list-style: none;
   padding: 0;
   margin: 0;
-  border-left: 2px solid var(--neutral-200);
+  position: relative;
 }
 
-[data-theme='dark'] .toc ul {
-  border-left-color: var(--neutral-700);
+/* Faint full-height track. */
+.toc ul::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--neutral-200);
+  border-radius: 2px;
+}
+
+[data-theme='dark'] .toc ul::before {
+  background: var(--neutral-700);
+}
+
+/* Colored fill whose height tracks reading progress (--toc-progress in px). */
+.toc ul::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 2px;
+  height: var(--toc-progress, 0px);
+  background: var(--brand-primary);
+  border-radius: 2px;
+  transition: height 0.15s ease-out;
+}
+
+[data-theme='dark'] .toc ul::after {
+  background: var(--brand-primary-light);
 }
 
 .tocLink {
   display: block;
   padding: 0.4rem 0 0.4rem 1rem;
-  margin-left: -2px;
-  border-left: 2px solid transparent;
   color: var(--neutral-600);
   font-size: 0.9rem;
   text-decoration: none !important;
-  transition: color 0.2s, border-color 0.2s;
+  transition: color 0.2s;
+  position: relative;
+  z-index: 1;
 }
 
 .tocLink:hover {
@@ -181,13 +236,11 @@
 
 .tocLinkActive {
   color: var(--brand-primary);
-  border-left-color: var(--brand-primary);
   font-weight: 700;
 }
 
 [data-theme='dark'] .tocLinkActive {
   color: var(--brand-primary-light);
-  border-left-color: var(--brand-primary-light);
 }
 
 /* --------------------------------------------------------- Content */
@@ -195,6 +248,7 @@
   min-width: 0;
 }
 
+/* ---- helper classes for interactive (hand-built) pages ---------------- */
 .block {
   margin-bottom: 3.5rem;
   scroll-margin-top: 5rem;
@@ -257,6 +311,7 @@
   font-size: 0.92rem;
   text-decoration: none !important;
   transition: transform 0.2s, box-shadow 0.2s, background 0.2s, border-color 0.2s;
+  cursor: pointer;
 }
 
 .btnPrimary {
@@ -287,39 +342,12 @@
   border-color: var(--neutral-600);
 }
 
-/* ---------------------------------------------------- Platform grid */
-.platformGrid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.25rem;
-  margin: 1.5rem 0;
-}
-
-@media (min-width: 700px) {
-  .platformGrid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-.platformCard {
-  background: var(--neutral-50);
-  border: 1px solid var(--neutral-200);
-  border-radius: 14px;
-  padding: 1.5rem;
-}
-
-[data-theme='dark'] .platformCard {
-  background: var(--neutral-800);
-  border-color: var(--neutral-700);
-}
-
 /* ----------------------------------------------------------- Steps */
 .steps {
   margin: 0;
   padding-left: 1.25rem;
   display: grid;
   gap: 0.6rem;
-  counter-reset: step;
 }
 
 .steps li {
@@ -329,22 +357,6 @@
 
 [data-theme='dark'] .steps li {
   color: var(--neutral-300);
-}
-
-/* ------------------------------------------------------- Two-column */
-.twoCol {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.5rem;
-  align-items: start;
-  margin: 1.25rem 0;
-}
-
-@media (min-width: 760px) {
-  .twoCol {
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
-  }
 }
 
 /* -------------------------------------------------------- Check list */
@@ -407,90 +419,6 @@
   padding: 0;
 }
 
-/* ---------------------------------------------------------- Figures */
-.figure {
-  margin: 0;
-}
-
-.figureImg {
-  width: 100%;
-  border-radius: 12px;
-  border: 1px solid var(--neutral-200);
-  box-shadow:
-    0 1px 2px rgba(15, 23, 42, 0.06),
-    0 4px 12px rgba(15, 23, 42, 0.08),
-    0 12px 28px rgba(15, 23, 42, 0.1);
-}
-
-[data-theme='dark'] .figureImg {
-  border-color: var(--neutral-700);
-}
-
-.figure figcaption {
-  margin-top: 0.6rem;
-  font-size: 0.82rem;
-  color: var(--neutral-500);
-  text-align: center;
-}
-
-/* --------------------------------------------------- Shot placeholder */
-.shotImg {
-  width: 100%;
-  display: block;
-  border-radius: 12px;
-  border: 1px solid var(--neutral-200);
-  box-shadow:
-    0 1px 2px rgba(15, 23, 42, 0.06),
-    0 4px 12px rgba(15, 23, 42, 0.08),
-    0 12px 28px rgba(15, 23, 42, 0.1);
-}
-
-[data-theme='dark'] .shotImg {
-  border-color: var(--neutral-700);
-}
-
-.shotPlaceholder {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  width: 100%;
-  min-height: 220px;
-  border: 2px dashed var(--neutral-300);
-  border-radius: 12px;
-  background:
-    repeating-linear-gradient(
-      45deg,
-      rgba(124, 92, 255, 0.03),
-      rgba(124, 92, 255, 0.03) 12px,
-      transparent 12px,
-      transparent 24px
-    );
-  color: var(--neutral-500);
-  text-align: center;
-  padding: 1.5rem;
-}
-
-[data-theme='dark'] .shotPlaceholder {
-  border-color: var(--neutral-600);
-  color: var(--neutral-400);
-}
-
-.shotTall {
-  min-height: 300px;
-}
-
-.shotIcon {
-  font-size: 1.85rem;
-  opacity: 0.8;
-}
-
-.shotLabel {
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
 /* -------------------------------------------------------- Callouts */
 .callout {
   display: flex;
@@ -515,11 +443,6 @@
   font-size: 1.1rem;
   line-height: 1.5;
   flex-shrink: 0;
-}
-
-.calloutMuted {
-  color: var(--neutral-500) !important;
-  font-size: 0.9rem;
 }
 
 .calloutTip {
@@ -559,178 +482,208 @@
   color: var(--brand-primary-light);
 }
 
-/* ----------------------------------------------------------- Table */
-.tableWrap {
-  overflow-x: auto;
-  margin: 1rem 0;
-  border: 1px solid var(--neutral-200);
-  border-radius: 12px;
-}
-
-[data-theme='dark'] .tableWrap {
-  border-color: var(--neutral-700);
-}
-
-.table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.9rem;
+/* --------------------------------------------------------- Figures */
+.figure {
   margin: 0;
 }
 
-.table th {
+.figureImg {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--neutral-200);
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 12px rgba(15, 23, 42, 0.08),
+    0 12px 28px rgba(15, 23, 42, 0.1);
+}
+
+[data-theme='dark'] .figureImg {
+  border-color: var(--neutral-700);
+}
+
+.figure figcaption {
+  margin-top: 0.6rem;
+  font-size: 0.82rem;
+  color: var(--neutral-500);
+  text-align: center;
+}
+
+/* =========================================================================
+ * Markdown body — makes rendered MDX match the hand-built helpers above.
+ * Applied when TutorialShell is given `markdown`.
+ * ========================================================================= */
+.markdown :global(h1) {
+  font-size: clamp(1.7rem, 3.4vw, 2.2rem);
+  font-weight: 800;
+  margin: 2rem 0 1rem;
+}
+
+.markdown :global(h2) {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 800;
+  color: var(--neutral-900);
+  margin: 2.25rem 0 1rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--neutral-200);
+  scroll-margin-top: 5rem;
+}
+
+[data-theme='dark'] .markdown :global(h2) {
+  color: #f1f5f9;
+  border-bottom-color: var(--neutral-700);
+}
+
+.markdown :global(h3) {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--neutral-800);
+  margin: 1.75rem 0 0.85rem;
+  scroll-margin-top: 5rem;
+}
+
+[data-theme='dark'] .markdown :global(h3) {
+  color: #e2e8f0;
+}
+
+.markdown :global(p) {
+  line-height: 1.7;
+  color: var(--neutral-700);
+  margin: 0 0 1.1rem;
+}
+
+[data-theme='dark'] .markdown :global(p) {
+  color: var(--neutral-300);
+}
+
+.markdown :global(a) {
+  color: var(--brand-primary);
+  font-weight: 600;
+}
+
+[data-theme='dark'] .markdown :global(a) {
+  color: var(--brand-primary-light);
+}
+
+.markdown :global(ul),
+.markdown :global(ol) {
+  padding-left: 1.4rem;
+  margin: 0 0 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.markdown :global(li) {
+  line-height: 1.6;
+  color: var(--neutral-700);
+}
+
+[data-theme='dark'] .markdown :global(li) {
+  color: var(--neutral-300);
+}
+
+.markdown :global(img) {
+  max-width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--neutral-200);
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 12px rgba(15, 23, 42, 0.08),
+    0 12px 28px rgba(15, 23, 42, 0.1);
+}
+
+[data-theme='dark'] .markdown :global(img) {
+  border-color: var(--neutral-700);
+}
+
+.markdown :global(code) {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.85em;
+  background: rgba(124, 92, 255, 0.08);
+  color: var(--brand-primary-dark);
+  padding: 0.15rem 0.4rem;
+  border-radius: 6px;
+}
+
+[data-theme='dark'] .markdown :global(code) {
+  background: rgba(167, 139, 250, 0.16);
+  color: var(--brand-primary-light);
+}
+
+.markdown :global(pre) {
+  background: var(--neutral-900);
+  color: #e2e8f0;
+  border-radius: 12px;
+  padding: 1.1rem 1.25rem;
+  overflow-x: auto;
+  margin: 1rem 0;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.markdown :global(pre code) {
+  background: transparent;
+  color: #e2e8f0;
+  padding: 0;
+  font-size: 0.82rem;
+  line-height: 1.7;
+}
+
+.markdown :global(blockquote) {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border-left: 4px solid var(--brand-primary);
+  background: rgba(124, 92, 255, 0.07);
+  border-radius: 0 12px 12px 0;
+}
+
+.markdown :global(blockquote) :global(p) {
+  margin: 0;
+}
+
+.markdown :global(table) {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  margin: 1.25rem 0;
+  display: block;
+  overflow-x: auto;
+}
+
+.markdown :global(th) {
   text-align: left;
   background: var(--neutral-50);
   font-weight: 700;
   color: var(--neutral-800);
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--neutral-200);
+  border: 1px solid var(--neutral-200);
 }
 
-[data-theme='dark'] .table th {
-  background: var(--neutral-800);
-  color: #f1f5f9;
-  border-bottom-color: var(--neutral-700);
-}
-
-.table td {
+.markdown :global(td) {
   padding: 0.7rem 1rem;
-  border-bottom: 1px solid var(--neutral-200);
+  border: 1px solid var(--neutral-200);
   color: var(--neutral-700);
   vertical-align: top;
 }
 
-[data-theme='dark'] .table td {
-  border-bottom-color: var(--neutral-700);
-  color: var(--neutral-300);
-}
-
-.table tr:last-child td {
-  border-bottom: none;
-}
-
-.table code {
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 0.82rem;
-  background: rgba(124, 92, 255, 0.08);
-  color: var(--brand-primary-dark);
-  padding: 0.2rem 0.45rem;
-  border-radius: 6px;
-  white-space: nowrap;
-}
-
-[data-theme='dark'] .table code {
-  background: rgba(167, 139, 250, 0.16);
-  color: var(--brand-primary-light);
-}
-
-/* ------------------------------------------------------------- FAQ */
-.faqList {
-  display: grid;
-  gap: 0.85rem;
-}
-
-.faqItem {
-  border: 1px solid var(--neutral-200);
-  border-radius: 12px;
-  background: var(--neutral-50);
-  overflow: hidden;
-}
-
-[data-theme='dark'] .faqItem {
-  background: var(--neutral-800);
+[data-theme='dark'] .markdown :global(th),
+[data-theme='dark'] .markdown :global(td) {
   border-color: var(--neutral-700);
 }
 
-.faqQ {
-  cursor: pointer;
-  padding: 1rem 1.25rem;
-  font-weight: 700;
-  color: var(--neutral-900);
-  list-style: none;
-  position: relative;
-  padding-right: 2.5rem;
-}
-
-.faqQ::-webkit-details-marker {
-  display: none;
-}
-
-.faqQ::after {
-  content: '+';
-  position: absolute;
-  right: 1.25rem;
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 1.25rem;
-  font-weight: 400;
-  color: var(--brand-primary);
-}
-
-.faqItem[open] .faqQ::after {
-  content: '−';
-}
-
-[data-theme='dark'] .faqQ {
+[data-theme='dark'] .markdown :global(th) {
+  background: var(--neutral-800);
   color: #f1f5f9;
 }
 
-.faqA {
-  padding: 0 1.25rem 1.25rem;
-}
-
-.faqA p {
-  margin: 0 0 0.5rem;
-  color: var(--neutral-700);
-}
-
-[data-theme='dark'] .faqA p {
+[data-theme='dark'] .markdown :global(td) {
   color: var(--neutral-300);
 }
 
-.driverLinks {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-  margin: 0.75rem 0;
+.markdown :global(hr) {
+  border: none;
+  border-top: 1px solid var(--neutral-200);
+  margin: 2.5rem 0;
 }
 
-.driverShots {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.25rem;
-  margin-top: 1rem;
-}
-
-@media (min-width: 700px) {
-  .driverShots {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-/* -------------------------------------------------------- Get help */
-.pathNote {
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 0.8rem;
-  background: var(--neutral-50);
-  border: 1px solid var(--neutral-200);
-  border-radius: 10px;
-  padding: 0.85rem 1rem;
-  color: var(--neutral-600) !important;
-  margin: 1.25rem 0;
-  line-height: 1.6;
-  word-break: break-word;
-}
-
-[data-theme='dark'] .pathNote {
-  background: var(--neutral-800);
-  border-color: var(--neutral-700);
-  color: var(--neutral-400) !important;
-}
-
-.helpButtons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 1.25rem;
+[data-theme='dark'] .markdown :global(hr) {
+  border-top-color: var(--neutral-700);
 }

--- a/src/components/useFromTutorials.js
+++ b/src/components/useFromTutorials.js
@@ -1,0 +1,33 @@
+import { useLocation } from '@docusaurus/router'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import { useEffect, useState } from 'react'
+
+/* =========================================================================
+ * useFromTutorials — detect arrival from the /tutorials hub.
+ * -------------------------------------------------------------------------
+ * The hub tags its outbound internal links with `?from=tutorials`. A landing
+ * page can call this hook to swap its "back" button so it returns to the hub
+ * the visitor actually came from, instead of that page's default parent.
+ *
+ * The flag starts false so the server render and the first client render match
+ * (no hydration mismatch); it flips to true in an effect once the URL is read.
+ *
+ * Returns { fromTutorials, href, label } — href/label are already localized.
+ * ========================================================================= */
+export default function useFromTutorials() {
+  const location = useLocation()
+  const { i18n } = useDocusaurusContext()
+  const locale = i18n.currentLocale === 'zh' ? 'zh' : 'en'
+
+  const [fromTutorials, setFromTutorials] = useState(false)
+  useEffect(() => {
+    const params = new URLSearchParams(location.search || '')
+    setFromTutorials(params.get('from') === 'tutorials')
+  }, [location.search])
+
+  return {
+    fromTutorials,
+    href: locale === 'zh' ? '/zh/tutorials' : '/tutorials',
+    label: locale === 'zh' ? '← 返回教程' : '← Back to tutorials',
+  }
+}

--- a/src/data/tutorials.js
+++ b/src/data/tutorials.js
@@ -1,0 +1,164 @@
+/* =========================================================================
+ * Tutorials manifest
+ * -------------------------------------------------------------------------
+ * Single source of truth for the /tutorials hub. Add a card by appending an
+ * entry to `tutorials.en` and `tutorials.zh` (keep the two in sync by `id`).
+ *
+ * Each entry:
+ *   id          unique, kebab-case
+ *   category    one of the keys in `categories` (drives the filter)
+ *   kind        'markdown' | 'interactive' | 'external'
+ *                 markdown    → prose/doc content rendered with shared style
+ *                               (a /docs page, or a page wrapping <MarkdownSection>)
+ *                 interactive → a hand-built HTML/React page (uses <TutorialShell>)
+ *                 external    → opens in a new tab (GitHub, YouTube, …)
+ *   href        destination. Internal routes start with '/'. Locale prefixing
+ *               for zh is handled by the page — author the plain (en) path here.
+ *   title       card title
+ *   description one/two sentence summary
+ *   tags        optional array of tag keys (see `tags` below)
+ *   level       optional 'beginner' | 'intermediate' | 'advanced'
+ *   duration    optional human string, e.g. '10 min'
+ *
+ * The `kind` badge and external-link behaviour are derived automatically on the
+ * page — you never style a card by hand, which is what keeps markdown and HTML
+ * entries visually consistent.
+ * ========================================================================= */
+
+/* ------------------------------------------------------------- Categories */
+/* Order here is the order of the filter chips. Sections may be empty for now. */
+export const categories = {
+  en: [
+    { id: 'basics', label: 'Basics' },
+    { id: 'ide', label: 'TuyaOpen IDE' },
+    { id: 'sdk', label: 'TuyaOpen SDK' },
+    { id: 'projects', label: 'Projects' },
+    { id: 'tutorials', label: 'Tutorials' },
+    { id: 'community', label: 'Community' },
+  ],
+  zh: [
+    { id: 'basics', label: '基础' },
+    { id: 'ide', label: 'TuyaOpen IDE' },
+    { id: 'sdk', label: 'TuyaOpen SDK' },
+    { id: 'projects', label: '项目' },
+    { id: 'tutorials', label: '教程' },
+    { id: 'community', label: '社区' },
+  ],
+}
+
+/* -------------------------------------------------------------- Kind meta */
+/* Small badge shown on every card so md / html / external read consistently. */
+export const kinds = {
+  en: {
+    markdown: { label: 'Guide' },
+    interactive: { label: 'Interactive' },
+    external: { label: 'External' },
+  },
+  zh: {
+    markdown: { label: '图文' },
+    interactive: { label: '交互' },
+    external: { label: '站外' },
+  },
+}
+
+/* -------------------------------------------------------------- Level meta */
+export const levels = {
+  en: {
+    beginner: 'Beginner',
+    intermediate: 'Intermediate',
+    advanced: 'Advanced',
+  },
+  zh: {
+    beginner: '入门',
+    intermediate: '进阶',
+    advanced: '高级',
+  },
+}
+
+/* --------------------------------------------------------------- Tag meta */
+/* Reuse a small palette; label per-locale, colours shared. */
+export const tags = {
+  en: {
+    flashing: { label: 'Flashing', color: '#f97316' },
+    setup: { label: 'Setup', color: '#3b82f6' },
+    cli: { label: 'CLI', color: '#64748b' },
+  },
+  zh: {
+    flashing: { label: '烧录', color: '#f97316' },
+    setup: { label: '配置', color: '#3b82f6' },
+    cli: { label: 'CLI', color: '#64748b' },
+  },
+}
+
+/* ------------------------------------------------------------- Tutorials */
+export const tutorials = {
+  en: [
+    {
+      id: 'tyutool-guide',
+      category: 'basics',
+      kind: 'interactive',
+      href: '/tools/tyutool-guide',
+      title: 'tyutool — flashing & authorization guide',
+      description:
+        'Install tyutool, flash your first board, authorize it for Tuya IoT, and fix common hiccups (GUI + CLI).',
+      tags: ['flashing', 'cli'],
+      level: 'beginner',
+    },
+    {
+      id: 'license-key',
+      category: 'basics',
+      kind: 'interactive',
+      href: '/pricing',
+      title: 'Get a license key',
+      description: 'Understand TuyaOpen authorization and how to obtain UUID / AuthKey credentials for your devices.',
+      tags: ['setup'],
+      level: 'beginner',
+    },
+    {
+      id: 'using-license-key',
+      category: 'basics',
+      kind: 'interactive',
+      href: '/tutorials/using-license-key',
+      title: 'Use your license key',
+      description:
+        'Write the UUID + AuthKey to a device with tyutool (GUI + CLI), then verify it activates against the Tuya Cloud.',
+      tags: ['setup', 'flashing'],
+      level: 'beginner',
+    },
+  ],
+
+  zh: [
+    {
+      id: 'tyutool-guide',
+      category: 'basics',
+      kind: 'interactive',
+      href: '/tools/tyutool-guide',
+      title: 'tyutool —— 烧录与授权指南',
+      description: '安装 tyutool、烧录第一块板子、为涂鸦 IoT 授权，并解决常见问题（GUI + CLI）。',
+      tags: ['flashing', 'cli'],
+      level: 'beginner',
+    },
+    {
+      id: 'license-key',
+      category: 'basics',
+      kind: 'interactive',
+      href: '/pricing',
+      title: '获取授权码',
+      description: '了解 TuyaOpen 授权机制，以及如何为你的设备获取 UUID / AuthKey 凭据。',
+      tags: ['setup'],
+      level: 'beginner',
+    },
+    {
+      id: 'using-license-key',
+      category: 'basics',
+      kind: 'interactive',
+      href: '/tutorials/using-license-key',
+      title: '使用授权码',
+      description: '用 tyutool（GUI + CLI）将 UUID + AuthKey 写入设备，并验证其在涂鸦云上成功激活。',
+      tags: ['setup', 'flashing'],
+      level: 'beginner',
+    },
+  ],
+}
+
+export default { categories, kinds, levels, tags, tutorials }

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -2,6 +2,7 @@ import Head from '@docusaurus/Head'
 import Link from '@docusaurus/Link'
 import useBaseUrl from '@docusaurus/useBaseUrl'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import useFromTutorials from '@site/src/components/useFromTutorials'
 import Layout from '@theme/Layout'
 import { clsx } from 'clsx'
 import React, { useEffect, useRef, useState } from 'react'
@@ -706,6 +707,7 @@ export default function Pricing() {
   const c = content[locale]
   const base = locale === 'zh' ? '/zh' : ''
   const guideHref = `${base}/pricing-guide`
+  const { fromTutorials, href: tutorialsHref, label: tutorialsLabel } = useFromTutorials()
   const tierImgs = [
     'https://images.tuyacn.com/fe-static/docs/img/9d2e76d8-1ee0-4243-a6a2-fa44ab8855e2.png', // free
     'https://images.tuyacn.com/fe-static/docs/img/30131d50-5cb6-4819-a849-884184eff257.png', // iot
@@ -757,6 +759,22 @@ export default function Pricing() {
         <section className={styles.hero}>
           <div className={styles.heroGlow} aria-hidden />
           <div className={styles.heroInner}>
+            {fromTutorials && (
+              <Link
+                to={tutorialsHref}
+                style={{
+                  display: 'block',
+                  width: 'fit-content',
+                  color: 'rgba(255, 255, 255, 0.8)',
+                  fontSize: '0.875rem',
+                  fontWeight: 600,
+                  marginBottom: '1.25rem',
+                  textDecoration: 'none',
+                }}
+              >
+                {tutorialsLabel}
+              </Link>
+            )}
             <span className={styles.heroBadge}>{c.badge}</span>
             <h1 className={styles.heroTitle}>
               <span className={styles.heroTitleGradient}>{c.heroTitle[0]}</span> {c.heroTitle[1]}

--- a/src/pages/tools/tyutool-guide.jsx
+++ b/src/pages/tools/tyutool-guide.jsx
@@ -2,8 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 import { clsx } from 'clsx';
+import useFromTutorials from '@site/src/components/useFromTutorials';
 import styles from './tyutool-guide.module.css';
 
 const GITHUB = 'https://github.com/tuya/tyutool';
@@ -181,11 +181,8 @@ tyutool authorize -p /dev/ttyUSB0 \\
             { label: 'Windows driver', href: 'https://www.wch.cn/downloads/ch343ser_exe.html' },
             { label: 'macOS driver', href: 'https://www.wch.cn/downloads/CH34XSER_MAC_ZIP.html' },
           ],
-          drivers: true,
         },
       ],
-      driverCaption13: 'macOS 13 — Privacy & Security',
-      driverCaption15: 'macOS 15 — search "login" in Settings',
     },
     help: {
       title: 'Getting help',
@@ -356,11 +353,8 @@ tyutool authorize -p /dev/ttyUSB0 \\
             { label: 'Windows 驱动', href: 'https://www.wch.cn/downloads/ch343ser_exe.html' },
             { label: 'macOS 驱动', href: 'https://www.wch.cn/downloads/CH34XSER_MAC_ZIP.html' },
           ],
-          drivers: true,
         },
       ],
-      driverCaption13: 'macOS 13 —— 隐私与安全性',
-      driverCaption15: 'macOS 15 —— 在设置中搜索"登录"',
     },
     help: {
       title: '获取帮助',
@@ -411,6 +405,7 @@ export default function TyutoolGuidePage() {
   const locale = i18n.currentLocale === 'zh' ? 'zh' : 'en';
   const c = content[locale];
   const overviewHref = locale === 'zh' ? '/zh/tools/tyutool' : '/tools/tyutool';
+  const { fromTutorials, href: tutorialsHref, label: tutorialsLabel } = useFromTutorials();
 
   const [activeId, setActiveId] = useState(c.nav[0].id);
   const contentRef = useRef(null);
@@ -436,8 +431,6 @@ export default function TyutoolGuidePage() {
   const flashImg = SHOTS.flashing;
   const serialImg = SHOTS.debug;
   const batchImg = SHOTS.batch;
-  const macos13 = useBaseUrl('/img/tyutool/macos13.png');
-  const macos15 = useBaseUrl('/img/tyutool/macos15.png');
 
   return (
     <Layout title={`tyutool — ${c.badge}`} description={c.meta}>
@@ -446,8 +439,8 @@ export default function TyutoolGuidePage() {
         <header className={styles.hero}>
           <div className={styles.heroGlow} aria-hidden />
           <div className={styles.heroInner}>
-            <Link to={overviewHref} className={styles.breadcrumb}>
-              {c.backToOverview}
+            <Link to={fromTutorials ? tutorialsHref : overviewHref} className={styles.breadcrumb}>
+              {fromTutorials ? tutorialsLabel : c.backToOverview}
             </Link>
             <span className={styles.heroBadge}>{c.badge}</span>
             <h1 className={styles.heroTitle}>{c.title}</h1>
@@ -653,18 +646,6 @@ export default function TyutoolGuidePage() {
                               {l.label} →
                             </a>
                           ))}
-                        </div>
-                      )}
-                      {item.drivers && (
-                        <div className={styles.driverShots}>
-                          <figure className={styles.figure}>
-                            <img src={macos13} alt={c.trouble.driverCaption13} className={styles.figureImg} />
-                            <figcaption>{c.trouble.driverCaption13}</figcaption>
-                          </figure>
-                          <figure className={styles.figure}>
-                            <img src={macos15} alt={c.trouble.driverCaption15} className={styles.figureImg} />
-                            <figcaption>{c.trouble.driverCaption15}</figcaption>
-                          </figure>
                         </div>
                       )}
                     </div>

--- a/src/pages/tutorials.jsx
+++ b/src/pages/tutorials.jsx
@@ -1,0 +1,229 @@
+import React, { useMemo, useState } from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+import BorderGlow from '@site/src/components/BorderGlow';
+import FlowingMenu from '@site/src/components/FlowingMenu';
+import { categories, levels, tags as tagMeta, tutorials } from '../data/tutorials';
+import styles from './tutorials.module.css';
+
+/* ---- Inline SVG icons (no emoji), Lucide-style, currentColor ----------- */
+const iconProps = {
+  width: 14,
+  height: 14,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 2,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+  'aria-hidden': true,
+};
+const ArrowIcon = ({ external }) => (
+  <svg {...iconProps} width={16} height={16} className={styles.ctaArrow}>
+    {external ? <path d="M7 17 17 7M7 7h10v10" /> : <path d="M5 12h14M13 6l6 6-6 6" />}
+  </svg>
+);
+
+/* BorderGlow theming — violet brand + orange accent, works light & dark. */
+const GLOW = {
+  backgroundColor: 'var(--tut-card-bg)',
+  colors: ['#a78bfa', '#7c5cff', '#ff6b35'],
+  glowColor: '255 92 76',
+  borderRadius: 18,
+  glowRadius: 30,
+  glowIntensity: 0.9,
+  coneSpread: 22,
+  edgeSensitivity: 24,
+  fillOpacity: 0.35,
+};
+
+/* Internal Docusaurus <Link> is NOT auto-localized — prepend /zh/ for zh. */
+function localize(href, locale) {
+  if (locale !== 'zh') return href;
+  if (!href.startsWith('/') || href.startsWith('/zh/')) return href;
+  return `/zh${href}`;
+}
+
+const COPY = {
+  en: {
+    title: 'Tutorials',
+    subtitle:
+      'Hands-on, user-facing guidance for TuyaOpen — pick your board, set up the IDE, learn the SDK, and follow along with projects, tutorials, and guides.',
+    all: 'All',
+    empty: 'No tutorials in this section yet — check back soon.',
+    countOne: 'tutorial',
+    countMany: 'tutorials',
+  },
+  zh: {
+    title: '教程',
+    subtitle:
+      '面向用户的 TuyaOpen 实操指引 —— 选择开发板、配置 IDE、学习 SDK，并跟随项目、教程与指南一步步动手。',
+    all: '全部',
+    empty: '该分类下暂无教程，敬请期待。',
+    countOne: '篇教程',
+    countMany: '篇教程',
+  },
+};
+
+function TutorialCard({ item, locale, catMap, levelMap, tagMap }) {
+  const external = item.kind === 'external';
+  // Tag internal links so the destination can offer a "back to tutorials" return.
+  const href = external ? item.href : `${localize(item.href, locale)}?from=tutorials`;
+  const cat = catMap[item.category];
+  const cta = external ? (locale === 'zh' ? '前往' : 'Visit') : locale === 'zh' ? '打开' : 'Open';
+  const meta = [item.level && levelMap[item.level], item.duration].filter(Boolean);
+
+  const body = (
+    <>
+      <div className={styles.cardTop}>
+        <span className={styles.cardCat}>
+          <span className={styles.cardCatDot} aria-hidden />
+          {cat?.label}
+        </span>
+      </div>
+
+      <h3 className={styles.cardTitle}>{item.title}</h3>
+      <p className={styles.cardDesc}>{item.description}</p>
+
+      {(item.tags || []).length > 0 && (
+        <div className={styles.tagRow}>
+          {item.tags.map((t) => {
+            const tag = tagMap[t];
+            if (!tag) return null;
+            return (
+              <span key={t} className={styles.tag}>
+                <span className={styles.tagDot} style={{ background: tag.color }} aria-hidden />
+                {tag.label}
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      <div className={styles.cardFooter}>
+        <span className={styles.cardMeta}>{meta.join(' · ')}</span>
+        <span className={styles.cardCta}>
+          {cta}
+          <ArrowIcon external={external} />
+        </span>
+      </div>
+    </>
+  );
+
+  const linkEl = external ? (
+    <a href={href} target="_blank" rel="noopener noreferrer" className={styles.card}>
+      {body}
+    </a>
+  ) : (
+    <Link to={href} className={styles.card}>
+      {body}
+    </Link>
+  );
+
+  return (
+    <BorderGlow className={styles.glowCard} {...GLOW}>
+      {linkEl}
+    </BorderGlow>
+  );
+}
+
+export default function TutorialsPage() {
+  const { siteConfig, i18n } = useDocusaurusContext();
+  const locale = i18n.currentLocale === 'zh' ? 'zh' : 'en';
+  const t = COPY[locale];
+
+  const cats = categories[locale] || categories.en;
+  const catMap = useMemo(() => Object.fromEntries(cats.map((c) => [c.id, c])), [cats]);
+  const levelMap = levels[locale] || levels.en;
+  const tagMap = tagMeta[locale] || tagMeta.en;
+  const items = tutorials[locale] || tutorials.en;
+
+  const [active, setActive] = useState('all');
+
+  const counts = useMemo(() => {
+    const c = { all: items.length };
+    cats.forEach((cat) => {
+      c[cat.id] = items.filter((it) => it.category === cat.id).length;
+    });
+    return c;
+  }, [items, cats]);
+
+  const shown = active === 'all' ? items : items.filter((it) => it.category === active);
+
+  const menuItems = useMemo(
+    () => [
+      { key: 'all', text: t.all, count: counts.all },
+      ...cats.map((c) => ({ key: c.id, text: c.label, count: counts[c.id] })),
+    ],
+    [t.all, cats, counts],
+  );
+
+  const activeLabel = active === 'all' ? t.all : catMap[active]?.label;
+
+  return (
+    <Layout title={t.title} description={t.subtitle}>
+      <Head>
+        <title>
+          {t.title} - {siteConfig.title}
+        </title>
+        <meta name="description" content={t.subtitle} />
+      </Head>
+
+      <main className={styles.root}>
+        {/* --------------------------------------------------------- Hero */}
+        <header className={styles.hero}>
+          <div className={styles.heroGlow} aria-hidden />
+          <div className={styles.heroInner}>
+            <span className={styles.heroBadge}>{locale === 'zh' ? '学习中心' : 'Learn'}</span>
+            <h1 className={styles.heroTitle}>{t.title}</h1>
+            <p className={styles.heroSubtitle}>{t.subtitle}</p>
+          </div>
+        </header>
+
+        {/* -------------------------------------- Body: sidebar + grid */}
+        <div className={styles.shell}>
+          <aside className={styles.sidebar}>
+            <div className={styles.sidebarSticky}>
+              <p className={styles.sidebarTitle}>{locale === 'zh' ? '分类' : 'Browse'}</p>
+              <FlowingMenu
+                items={menuItems}
+                activeKey={active}
+                onSelect={setActive}
+                marqueeBgColor="#7c5cff"
+                marqueeTextColor="#ffffff"
+              />
+            </div>
+          </aside>
+
+          <div className={styles.main}>
+            <div className={styles.mainHead}>
+              <h2 className={styles.mainTitle}>{activeLabel}</h2>
+              <span className={styles.resultCount}>
+                {shown.length} {shown.length === 1 ? t.countOne : t.countMany}
+              </span>
+            </div>
+            {shown.length === 0 ? (
+              <p className={styles.empty}>{t.empty}</p>
+            ) : (
+              <div className={styles.grid}>
+                {shown.map((item) => (
+                  <TutorialCard
+                    key={item.id}
+                    item={item}
+                    locale={locale}
+                    catMap={catMap}
+                    levelMap={levelMap}
+                    tagMap={tagMap}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/tutorials.module.css
+++ b/src/pages/tutorials.module.css
@@ -1,0 +1,423 @@
+/* =========================================================================
+ * Tutorials hub — filterable card grid. Shares the tutorial design language.
+ * ========================================================================= */
+.root {
+  --brand-primary: #7c5cff;
+  --brand-primary-light: #a78bfa;
+  --brand-primary-dark: #5b3fd6;
+  --brand-accent: #ff6b35;
+  --neutral-50: #f8fafc;
+  --neutral-100: #f1f5f9;
+  --neutral-200: #e2e8f0;
+  --neutral-300: #cbd5e1;
+  --neutral-400: #94a3b8;
+  --neutral-500: #64748b;
+  --neutral-600: #475569;
+  --neutral-700: #334155;
+  --neutral-800: #1e293b;
+  --neutral-900: #0f172a;
+
+  /* Card surface consumed by BorderGlow (--card-bg) — theme aware. */
+  --tut-card-bg: #ffffff;
+  --tut-card-border: rgba(15, 23, 42, 0.08);
+
+  color: var(--neutral-900);
+  /* clip (not hidden) so the sticky filter bar isn't trapped in a scroll box. */
+  overflow-x: clip;
+}
+
+[data-theme='dark'] .root {
+  --tut-card-bg: #141b2d;
+  --tut-card-border: rgba(255, 255, 255, 0.08);
+  color: #e2e8f0;
+}
+
+/* ------------------------------------------------------------------ Hero */
+.hero {
+  position: relative;
+  padding: 3.75rem 1rem 3.25rem;
+  background: linear-gradient(135deg, #0f172a 0%, #312e81 50%, var(--brand-primary) 100%);
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(124, 92, 255, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(124, 92, 255, 0.08) 1px, transparent 1px);
+  background-size: 60px 60px;
+  pointer-events: none;
+}
+
+.heroGlow {
+  position: absolute;
+  width: min(560px, 90vw);
+  height: min(560px, 90vw);
+  background: radial-gradient(circle, rgba(124, 92, 255, 0.35) 0%, transparent 70%);
+  top: -220px;
+  right: -120px;
+  pointer-events: none;
+}
+
+.heroInner {
+  position: relative;
+  z-index: 1;
+  max-width: 1180px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.heroBadge {
+  display: inline-block;
+  background: rgba(255, 107, 53, 0.2);
+  border: 1px solid rgba(255, 107, 53, 0.35);
+  padding: 0.4rem 0.9rem;
+  border-radius: 9999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 1rem;
+}
+
+.heroTitle {
+  font-size: clamp(2.1rem, 5vw, 3rem);
+  font-weight: 800;
+  line-height: 1.1;
+  color: #fff;
+  margin-bottom: 0.75rem;
+}
+
+.heroSubtitle {
+  font-size: 1.1rem;
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.88);
+  max-width: 52rem;
+  margin: 0;
+}
+
+/* ------------------------------------------------- Body: sidebar + grid */
+.shell {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 2.25rem 1rem 4.5rem;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.75rem;
+}
+
+@media (min-width: 997px) {
+  .shell {
+    grid-template-columns: 244px 1fr;
+    gap: 2.5rem;
+    align-items: start;
+  }
+}
+
+/* -------------------------------------------------------------- Sidebar */
+.sidebar {
+  min-width: 0;
+}
+
+@media (min-width: 997px) {
+  .sidebarSticky {
+    position: sticky;
+    top: 5rem;
+  }
+}
+
+.sidebarTitle {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--neutral-500);
+  margin: 0 0 0.75rem;
+}
+
+@media (max-width: 996px) {
+  .sidebarTitle {
+    display: none;
+  }
+}
+
+/* ------------------------------------------------------------------ Main */
+.main {
+  min-width: 0;
+}
+
+.mainHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.4rem;
+  padding-bottom: 0.9rem;
+  border-bottom: 1px solid var(--tut-card-border);
+}
+
+.mainTitle {
+  font-size: 1.4rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--neutral-900);
+  margin: 0;
+}
+
+[data-theme='dark'] .mainTitle {
+  color: #f8fafc;
+}
+
+.resultCount {
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--neutral-500);
+}
+
+.empty {
+  color: var(--neutral-500);
+  font-size: 1rem;
+  padding: 3rem 0;
+  text-align: center;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+@media (min-width: 620px) {
+  .grid {
+    grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+  }
+}
+
+/* ------------------------------------------------------------------ Card */
+/* BorderGlow is the visual frame; .glowCard tunes it into a grid item. */
+.glowCard {
+  height: 100%;
+  border-radius: 18px;
+  border-color: var(--tut-card-border) !important;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04), 0 8px 24px -14px rgba(15, 23, 42, 0.25) !important;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.glowCard:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04), 0 22px 44px -18px rgba(15, 23, 42, 0.35) !important;
+}
+
+[data-theme='dark'] .glowCard:hover {
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 22px 44px -18px rgba(0, 0, 0, 0.7) !important;
+}
+
+/* Clip the inner content to the rounded frame. */
+.glowCard :global(.border-glow-inner) {
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glowCard,
+  .glowCard:hover {
+    transform: none;
+  }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
+  padding: 1.5rem 1.5rem 1.35rem;
+  text-decoration: none !important;
+  color: inherit !important;
+  background: transparent;
+}
+
+.cardTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 1.1rem;
+}
+
+.cardCat {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--neutral-500);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.cardCatDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--brand-primary), var(--brand-accent));
+  box-shadow: 0 0 8px rgba(124, 92, 255, 0.6);
+}
+
+[data-theme='dark'] .cardCat {
+  color: var(--neutral-400);
+}
+
+.kindBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.24rem 0.6rem;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.kindBadge svg {
+  opacity: 0.9;
+}
+
+.kind_markdown {
+  background: rgba(37, 99, 235, 0.1);
+  color: #2563eb;
+  border-color: rgba(37, 99, 235, 0.22);
+}
+
+.kind_interactive {
+  background: rgba(124, 92, 255, 0.1);
+  color: var(--brand-primary-dark);
+  border-color: rgba(124, 92, 255, 0.28);
+}
+
+.kind_external {
+  background: rgba(100, 116, 139, 0.12);
+  color: var(--neutral-600);
+  border-color: rgba(100, 116, 139, 0.28);
+}
+
+[data-theme='dark'] .kind_markdown {
+  color: #93c5fd;
+}
+
+[data-theme='dark'] .kind_interactive {
+  color: var(--brand-primary-light);
+}
+
+[data-theme='dark'] .kind_external {
+  color: var(--neutral-300);
+}
+
+.cardTitle {
+  font-size: 1.18rem;
+  font-weight: 700;
+  color: var(--neutral-900);
+  margin: 0 0 0.55rem;
+  line-height: 1.32;
+  letter-spacing: -0.01em;
+}
+
+[data-theme='dark'] .cardTitle {
+  color: #f8fafc;
+}
+
+.cardDesc {
+  font-size: 0.9rem;
+  line-height: 1.62;
+  color: var(--neutral-600);
+  margin: 0 0 1.15rem;
+  flex-grow: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+[data-theme='dark'] .cardDesc {
+  color: var(--neutral-400);
+}
+
+.tagRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.7rem;
+  margin-bottom: 1.15rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--neutral-500);
+}
+
+[data-theme='dark'] .tag {
+  color: var(--neutral-400);
+}
+
+.tagDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.cardFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: auto;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--tut-card-border);
+}
+
+.cardMeta {
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--neutral-500);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+[data-theme='dark'] .cardMeta {
+  color: var(--neutral-400);
+}
+
+.cardCta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--brand-primary);
+  white-space: nowrap;
+}
+
+[data-theme='dark'] .cardCta {
+  color: var(--brand-primary-light);
+}
+
+.ctaArrow {
+  transition: transform 0.2s ease;
+}
+
+.glowCard:hover .ctaArrow {
+  transform: translateX(3px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ctaArrow,
+  .glowCard:hover .ctaArrow {
+    transform: none;
+  }
+}

--- a/src/pages/tutorials/interactive-template.jsx
+++ b/src/pages/tutorials/interactive-template.jsx
@@ -1,0 +1,211 @@
+import React, { useState } from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { clsx } from 'clsx';
+import TutorialShell from '@site/src/components/TutorialShell';
+import shell from '@site/src/components/TutorialShell/styles.module.css';
+import styles from './interactive-template.module.css';
+
+/* =========================================================================
+ * INTERACTIVE TUTORIAL TEMPLATE  (kind: 'interactive')
+ * -------------------------------------------------------------------------
+ * Copy this file to src/pages/tutorials/<your-slug>.jsx to start a new
+ * interactive HTML tutorial, then add a matching entry to src/data/tutorials.js
+ * with kind: 'interactive' and href: '/tutorials/<your-slug>'.
+ *
+ * Rules of the road for consistency:
+ *   • Wrap everything in <TutorialShell> — it provides the hero, the sticky
+ *     table of contents, and the shared page frame.
+ *   • Build sections with <section id="…"> so the TOC can track them, and pass
+ *     the same ids/labels to the shell's `nav` prop.
+ *   • Use the exported helper classes from TutorialShell/styles.module.css
+ *     (shell.block, shell.h2, shell.h3, shell.lead, shell.steps,
+ *     shell.checkList, shell.callout, shell.codeBlock, shell.btnPrimary…).
+ *     Only reach for a local module (styles.*) for genuinely bespoke widgets.
+ *   • Keep copy bilingual via the `content` object, exactly like this file.
+ * ========================================================================= */
+
+const content = {
+  en: {
+    badge: 'Interactive tutorial',
+    title: 'Interactive tutorial — template',
+    subtitle:
+      'A copy-me reference for building interactive TuyaOpen tutorials. It shows the hero, sticky contents, callouts, code blocks, and a small live widget — all in the shared style.',
+    meta: ['Beginner', 'Template'],
+    nav: [
+      { id: 'intro', label: 'Introduction' },
+      { id: 'steps', label: 'Steps' },
+      { id: 'widget', label: 'Live widget' },
+      { id: 'next', label: 'Next steps' },
+    ],
+    introTitle: 'Introduction',
+    introLead:
+      'Interactive tutorials are plain React pages. Because they render inside TutorialShell, they automatically match the markdown tutorials — same hero, same typography, same dark mode.',
+    introTip:
+      'Prefer the shell helper classes over custom CSS. That is what keeps every tutorial looking like it belongs to the same set.',
+    stepsTitle: 'Steps',
+    stepsLead: 'Numbered steps use the shell’s step list so spacing and colour are consistent:',
+    steps: [
+      'Copy this file and rename it to your tutorial slug.',
+      'Update the bilingual `content` object with your copy.',
+      'Add matching <section id> blocks and TOC entries.',
+      'Register the tutorial in src/data/tutorials.js.',
+    ],
+    codeIntro: 'Show commands with the shared code block:',
+    widgetTitle: 'Live widget',
+    widgetLead:
+      'This is the part markdown cannot do — real interactivity. Pick a board and the flash command updates instantly.',
+    widgetBoardLabel: 'Board',
+    widgetPortLabel: 'Port',
+    widgetPortAuto: 'auto-detect',
+    widgetOut: 'Flash command',
+    nextTitle: 'Next steps',
+    nextLead: 'When your tutorial is ready:',
+    nextPoints: [
+      'Verify it renders in both English and 简体中文.',
+      'Confirm the card shows up under the right filter on /tutorials.',
+      'Ask for review before publishing.',
+    ],
+    docsBtn: 'Browse the docs',
+  },
+  zh: {
+    badge: '交互式教程',
+    title: '交互式教程 — 模板',
+    subtitle:
+      '一个可复制的参考页，用于构建 TuyaOpen 交互式教程。展示了主视觉、粘性目录、提示框、代码块和一个实时小组件 —— 全部采用共享样式。',
+    meta: ['入门', '模板'],
+    nav: [
+      { id: 'intro', label: '简介' },
+      { id: 'steps', label: '步骤' },
+      { id: 'widget', label: '实时组件' },
+      { id: 'next', label: '后续' },
+    ],
+    introTitle: '简介',
+    introLead:
+      '交互式教程就是普通的 React 页面。由于它们在 TutorialShell 中渲染，会自动与 Markdown 教程保持一致 —— 相同的主视觉、相同的排版、相同的暗色模式。',
+    introTip: '优先使用外壳提供的辅助类而非自定义 CSS，这样每篇教程看起来才像同一套。',
+    stepsTitle: '步骤',
+    stepsLead: '编号步骤使用外壳的步骤列表，间距与配色保持一致：',
+    steps: [
+      '复制本文件并重命名为你的教程别名。',
+      '用你的文案更新双语 `content` 对象。',
+      '添加对应的 <section id> 区块与目录项。',
+      '在 src/data/tutorials.js 中注册该教程。',
+    ],
+    codeIntro: '用共享代码块展示命令：',
+    widgetTitle: '实时组件',
+    widgetLead: '这是 Markdown 做不到的部分 —— 真正的交互。选择开发板，烧录命令会立即更新。',
+    widgetBoardLabel: '开发板',
+    widgetPortLabel: '串口',
+    widgetPortAuto: '自动检测',
+    widgetOut: '烧录命令',
+    nextTitle: '后续',
+    nextLead: '当你的教程准备就绪：',
+    nextPoints: [
+      '确认在英文与简体中文下都能正常渲染。',
+      '确认卡片在 /tutorials 的正确分类下出现。',
+      '发布前请先请人评审。',
+    ],
+    docsBtn: '浏览文档',
+  },
+};
+
+const BOARDS = [
+  { id: 't5ai', label: 'T5AI' },
+  { id: 'bk7231n', label: 'BK7231N' },
+  { id: 'esp32', label: 'ESP32' },
+];
+
+function FlashWidget({ c }) {
+  const [board, setBoard] = useState(BOARDS[0].id);
+  const [port, setPort] = useState('');
+  const cmd = `tyutool write -d ${board}${port ? ` -p ${port}` : ''} -f app_QIO.bin`;
+
+  return (
+    <div className={styles.widget}>
+      <div className={styles.widgetControls}>
+        <label className={styles.widgetField}>
+          <span>{c.widgetBoardLabel}</span>
+          <select value={board} onChange={(e) => setBoard(e.target.value)} className={styles.select}>
+            {BOARDS.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className={styles.widgetField}>
+          <span>{c.widgetPortLabel}</span>
+          <input
+            className={styles.input}
+            value={port}
+            placeholder={c.widgetPortAuto}
+            onChange={(e) => setPort(e.target.value.trim())}
+          />
+        </label>
+      </div>
+      <div className={styles.widgetOut}>
+        <span className={styles.widgetOutLabel}>{c.widgetOut}</span>
+        <code>{cmd}</code>
+      </div>
+    </div>
+  );
+}
+
+export default function InteractiveTemplate() {
+  const { i18n } = useDocusaurusContext();
+  const locale = i18n.currentLocale === 'zh' ? 'zh' : 'en';
+  const c = content[locale];
+  const docsHref = locale === 'zh' ? '/zh/docs/about-tuyaopen' : '/docs/about-tuyaopen';
+
+  return (
+    <TutorialShell badge={c.badge} title={c.title} subtitle={c.subtitle} meta={c.meta} nav={c.nav}>
+      {/* Intro */}
+      <section id="intro" className={shell.block}>
+        <h2 className={shell.h2}>{c.introTitle}</h2>
+        <p className={shell.lead}>{c.introLead}</p>
+        <div className={clsx(shell.callout, shell.calloutTip)}>
+          <p>{c.introTip}</p>
+        </div>
+      </section>
+
+      {/* Steps */}
+      <section id="steps" className={shell.block}>
+        <h2 className={shell.h2}>{c.stepsTitle}</h2>
+        <p className={shell.lead}>{c.stepsLead}</p>
+        <ol className={shell.steps}>
+          {c.steps.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ol>
+        <p>{c.codeIntro}</p>
+        <pre className={shell.codeBlock}>
+          <code>{`cp interactive-template.jsx my-tutorial.jsx
+# then edit content{} and register it in src/data/tutorials.js`}</code>
+        </pre>
+      </section>
+
+      {/* Widget */}
+      <section id="widget" className={shell.block}>
+        <h2 className={shell.h2}>{c.widgetTitle}</h2>
+        <p className={shell.lead}>{c.widgetLead}</p>
+        <FlashWidget c={c} />
+      </section>
+
+      {/* Next */}
+      <section id="next" className={shell.block}>
+        <h2 className={shell.h2}>{c.nextTitle}</h2>
+        <p className={shell.lead}>{c.nextLead}</p>
+        <ul className={shell.checkList}>
+          {c.nextPoints.map((p, i) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+        <p style={{ marginTop: '1.5rem' }}>
+          <a className={shell.btnPrimary} href={docsHref}>
+            {c.docsBtn}
+          </a>
+        </p>
+      </section>
+    </TutorialShell>
+  );
+}

--- a/src/pages/tutorials/interactive-template.module.css
+++ b/src/pages/tutorials/interactive-template.module.css
@@ -1,0 +1,97 @@
+/* Bespoke widget styles for the interactive tutorial template.
+ * Keep local modules small — anything reusable belongs in TutorialShell. */
+
+.widget {
+  border: 1px solid var(--neutral-200, #e2e8f0);
+  border-radius: 14px;
+  padding: 1.25rem;
+  background: var(--neutral-50, #f8fafc);
+  margin: 1.25rem 0;
+}
+
+[data-theme='dark'] .widget {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+.widgetControls {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-bottom: 1.1rem;
+}
+
+@media (min-width: 560px) {
+  .widgetControls {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.widgetField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+[data-theme='dark'] .widgetField {
+  color: #94a3b8;
+}
+
+.select,
+.input {
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #0f172a;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+[data-theme='dark'] .select,
+[data-theme='dark'] .input {
+  background: #0f172a;
+  border-color: #475569;
+  color: #e2e8f0;
+}
+
+.select:focus,
+.input:focus {
+  outline: none;
+  border-color: #7c5cff;
+  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.2);
+}
+
+.widgetOut {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.widgetOutLabel {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.widgetOut code {
+  display: block;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.85rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  overflow-x: auto;
+  white-space: pre;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}

--- a/src/pages/tutorials/markdown-template.jsx
+++ b/src/pages/tutorials/markdown-template.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import TutorialShell from '@site/src/components/TutorialShell';
+import MarkdownSection from '@site/src/components/MarkdownSection';
+
+/* =========================================================================
+ * MARKDOWN TUTORIAL TEMPLATE  (kind: 'markdown')
+ * -------------------------------------------------------------------------
+ * Use this when the tutorial is plain prose and you'd rather author it in
+ * Markdown than JSX. The .md file lives as a partial (underscore prefix so it
+ * is NOT routed on its own) under docs/tutorials/, and is rendered here inside
+ * TutorialShell with `markdown` — giving it the SAME look as the interactive
+ * tutorials.
+ *
+ * To make your own:
+ *   1. Write docs/tutorials/_my-tutorial.md
+ *   2. Copy this file to src/pages/tutorials/my-tutorial.jsx and point SOURCE
+ *      at your file (per-locale if you have a zh version).
+ *   3. Register it in src/data/tutorials.js with kind: 'markdown'.
+ *
+ * (Tutorials that are really just a normal /docs page can skip this wrapper
+ *  entirely — set the manifest href straight to the /docs/... route.)
+ * ========================================================================= */
+
+const SOURCE = {
+  en: '/docs/tutorials/_sample-getting-started.md',
+  zh: '/docs/tutorials/_sample-getting-started.md',
+};
+
+const content = {
+  en: {
+    badge: 'Markdown tutorial',
+    title: 'Markdown tutorial — template',
+    subtitle:
+      'This whole page body is a Markdown file rendered inside the shared tutorial shell. Same hero, same typography, same dark mode as the interactive tutorials — just authored in .md.',
+    meta: ['Beginner', 'Template'],
+  },
+  zh: {
+    badge: 'Markdown 教程',
+    title: 'Markdown 教程 — 模板',
+    subtitle:
+      '整个页面正文都是一个 Markdown 文件，在共享的教程外壳中渲染。与交互式教程相同的主视觉、排版与暗色模式 —— 只是用 .md 编写。',
+    meta: ['入门', '模板'],
+  },
+};
+
+export default function MarkdownTemplate() {
+  const { i18n } = useDocusaurusContext();
+  const locale = i18n.currentLocale === 'zh' ? 'zh' : 'en';
+  const c = content[locale];
+
+  return (
+    <TutorialShell badge={c.badge} title={c.title} subtitle={c.subtitle} meta={c.meta} markdown>
+      <MarkdownSection source={SOURCE[locale] || SOURCE.en} />
+    </TutorialShell>
+  );
+}

--- a/src/pages/tutorials/using-license-key.jsx
+++ b/src/pages/tutorials/using-license-key.jsx
@@ -1,0 +1,247 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { clsx } from 'clsx';
+import TutorialShell from '@site/src/components/TutorialShell';
+import shell from '@site/src/components/TutorialShell/styles.module.css';
+
+/* =========================================================================
+ * TUTORIAL: Use your license key (authorize a device)   kind: 'interactive'
+ * Registered in src/data/tutorials.js under the "guides" category.
+ * ========================================================================= */
+
+const content = {
+  en: {
+    badge: 'Guide',
+    title: 'Use your license key',
+    subtitle:
+      'A TuyaOpen license key is a UUID + AuthKey pair. This guide shows how to write it to a device and verify it, so the device can connect to the Tuya Cloud.',
+    meta: ['Beginner', 'Authorization'],
+    nav: [
+      { id: 'what', label: 'What it is' },
+      { id: 'get', label: 'Get a key' },
+      { id: 'write', label: 'Write it to a device' },
+      { id: 'verify', label: 'Verify' },
+      { id: 'trouble', label: 'Troubleshooting' },
+    ],
+    whatTitle: 'What a license key is',
+    whatLead:
+      'Every TuyaOpen device that connects to the Tuya Cloud needs one license key — a UUID (identity) and an AuthKey (secret), written to the device over the same UART you flash with.',
+    whatPoints: [
+      'One key authorizes one device. Keys are not reusable across devices.',
+      'TuyaOpen and TuyaOS keys are not interchangeable — use a TuyaOpen key.',
+      'A key is separate from firmware: you can re-flash firmware without re-writing the key.',
+    ],
+    getTitle: 'Get a key',
+    getLead:
+      'You can get a free trial key for evaluation, or buy keys in bulk for production. See the licensing page for options and pricing.',
+    getBtn: 'Get a license key',
+    getPlatform: 'Tuya Developer Platform',
+    getNote: 'Have your UUID and AuthKey ready before you start — you will paste them into tyutool.',
+    writeTitle: 'Write the key to a device',
+    writeLead: 'The easiest way is tyutool. Connect the board over USB, then use the GUI or the CLI.',
+    guiTitle: 'With the tyutool GUI',
+    guiSteps: [
+      'Open tyutool and switch to the Authorize tab.',
+      'Select your target chip — tyutool applies the correct serial settings automatically.',
+      'Select the authorization serial port.',
+      'Paste the UUID and AuthKey.',
+      'Click Start authorization, then read back the state to confirm.',
+    ],
+    cliTitle: 'With the CLI',
+    cliIntro: 'Same operation from a terminal:',
+    cliCode: `# Read the current authorization state
+tyutool authorize -p /dev/ttyUSB0
+
+# Write a new UUID + AuthKey (both required)
+tyutool authorize -p /dev/ttyUSB0 \\
+    --uuid <UUID> --authkey <AUTHKEY>`,
+    fullGuide: 'Full flashing & authorization guide',
+    verifyTitle: 'Verify it worked',
+    verifyLead: 'Confirm the key is stored, then check the device activates against the cloud.',
+    verifyPoints: [
+      'Read the authorization state back (GUI read-back, or the CLI read command above) and confirm the UUID matches.',
+      'Reboot the device and watch the serial log — a successful activation reports the device coming online.',
+      'Pair the device in the Tuya app; it activates against the cloud using the written credentials.',
+    ],
+    troubleTitle: 'Troubleshooting',
+    trouble: [
+      {
+        q: 'Do I need to re-write the key every time I update the firmware?',
+        a: 'No. The key is stored in the device’s KV storage and survives firmware re-flashes — you only need to write it again after a full chip erase.',
+      },
+      {
+        q: 'Authorization fails or times out',
+        a: 'Make sure you selected the authorization/flash port (not the log port), and that no serial monitor is holding the port, then retry.',
+      },
+      {
+        q: 'Device flashed but won’t connect to the cloud',
+        a: 'The firmware is flashed but no key was written, or the wrong key type was used. Re-check that a TuyaOpen (not TuyaOS) UUID + AuthKey is stored.',
+      },
+      {
+        q: 'Already-flashed device that only needs a license',
+        a: 'Use the auth-only "other" chip option in tyutool — it writes the key without re-flashing firmware.',
+      },
+    ],
+  },
+  zh: {
+    badge: '指南',
+    title: '使用授权码',
+    subtitle:
+      'TuyaOpen 的授权码是一对 UUID + AuthKey。本教程讲解如何把它写入设备并验证，从而让设备接入涂鸦云。',
+    meta: ['入门', '授权'],
+    nav: [
+      { id: 'what', label: '什么是授权码' },
+      { id: 'get', label: '获取授权码' },
+      { id: 'write', label: '写入设备' },
+      { id: 'verify', label: '验证' },
+      { id: 'trouble', label: '故障排查' },
+    ],
+    whatTitle: '什么是授权码',
+    whatLead:
+      '每一台接入涂鸦云的 TuyaOpen 设备都需要一个授权码 —— 即 UUID（身份）与 AuthKey（密钥），通过与烧录相同的 UART 写入设备。',
+    whatPoints: [
+      '一个授权码授权一台设备，不能在多台设备间复用。',
+      'TuyaOpen 与 TuyaOS 的授权码不能互换 —— 请使用 TuyaOpen 授权码。',
+      '授权码与固件相互独立：重新烧录固件时无需重写授权码。',
+    ],
+    getTitle: '获取授权码',
+    getLead: '你可以领取免费试用授权码用于评估，或批量购买用于量产。授权与价格详情见授权页面。',
+    getBtn: '获取授权码',
+    getPlatform: '涂鸦开发者平台',
+    getNote: '开始前请准备好 UUID 与 AuthKey —— 稍后会粘贴到 tyutool 中。',
+    writeTitle: '将授权码写入设备',
+    writeLead: '最简单的方式是使用 tyutool。用 USB 连接开发板后，选择 GUI 或 CLI 操作。',
+    guiTitle: '使用 tyutool GUI',
+    guiSteps: [
+      '打开 tyutool，切换到"授权"标签页。',
+      '选择目标芯片 —— tyutool 会自动应用对应的串口参数。',
+      '选择授权串口。',
+      '粘贴 UUID 和 AuthKey。',
+      '点击"开始授权"，随后回读状态以确认。',
+    ],
+    cliTitle: '使用 CLI',
+    cliIntro: '在终端中完成同样的操作：',
+    cliCode: `# 读取当前授权状态
+tyutool authorize -p /dev/ttyUSB0
+
+# 写入新的 UUID + AuthKey（两者都必填）
+tyutool authorize -p /dev/ttyUSB0 \\
+    --uuid <UUID> --authkey <AUTHKEY>`,
+    fullGuide: '完整的烧录与授权指南',
+    verifyTitle: '验证是否成功',
+    verifyLead: '先确认授权码已写入，再检查设备能否在云端激活。',
+    verifyPoints: [
+      '回读授权状态（GUI 回读，或上面的 CLI 读取命令），确认 UUID 一致。',
+      '重启设备并观察串口日志 —— 激活成功会提示设备上线。',
+      '在涂鸦 App 中配网；设备会使用写入的凭据在云端激活。',
+    ],
+    troubleTitle: '故障排查',
+    trouble: [
+      {
+        q: '每次更新固件都要重新写入授权码吗？',
+        a: '不需要。授权码保存在设备的 KV 存储中，重新烧录固件不会丢失；只有在整片擦除（full erase）之后才需要重新写入。',
+      },
+      {
+        q: '授权失败或超时',
+        a: '确认选择的是授权/烧录口（而非日志口），且没有串口监视器占用该串口，然后重试。',
+      },
+      {
+        q: '固件已烧录但无法接入云端',
+        a: '可能只烧录了固件却没有写入授权码，或用错了授权码类型。请确认写入的是 TuyaOpen（而非 TuyaOS）的 UUID + AuthKey。',
+      },
+      {
+        q: '已烧录、只需授权的设备',
+        a: '在 tyutool 中使用授权专用的"other"芯片选项 —— 它只写入授权码，不重新烧录固件。',
+      },
+    ],
+  },
+};
+
+const PLATFORM = 'https://platform.tuya.com/purchase/index?type=6';
+
+export default function UsingLicenseKey() {
+  const { i18n } = useDocusaurusContext();
+  const locale = i18n.currentLocale === 'zh' ? 'zh' : 'en';
+  const c = content[locale];
+  const pricingHref = locale === 'zh' ? '/zh/pricing' : '/pricing';
+  const tyutoolHref = locale === 'zh' ? '/zh/tools/tyutool-guide' : '/tools/tyutool-guide';
+
+  return (
+    <TutorialShell badge={c.badge} title={c.title} subtitle={c.subtitle} meta={c.meta} nav={c.nav}>
+      {/* What it is */}
+      <section id="what" className={shell.block}>
+        <h2 className={shell.h2}>{c.whatTitle}</h2>
+        <p className={shell.lead}>{c.whatLead}</p>
+        <ul className={shell.checkList}>
+          {c.whatPoints.map((p, i) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Get a key */}
+      <section id="get" className={shell.block}>
+        <h2 className={shell.h2}>{c.getTitle}</h2>
+        <p className={shell.lead}>{c.getLead}</p>
+        <p style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem' }}>
+          <a className={shell.btnPrimary} href={pricingHref}>
+            {c.getBtn}
+          </a>
+          <a className={shell.btnGhost} href={PLATFORM} target="_blank" rel="noopener noreferrer">
+            {c.getPlatform} →
+          </a>
+        </p>
+        <div className={clsx(shell.callout, shell.calloutInfo)}>
+          <p>{c.getNote}</p>
+        </div>
+      </section>
+
+      {/* Write it */}
+      <section id="write" className={shell.block}>
+        <h2 className={shell.h2}>{c.writeTitle}</h2>
+        <p className={shell.lead}>{c.writeLead}</p>
+
+        <h3 className={shell.h3}>{c.guiTitle}</h3>
+        <ol className={shell.steps}>
+          {c.guiSteps.map((s, i) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ol>
+
+        <h3 className={shell.h3}>{c.cliTitle}</h3>
+        <p>{c.cliIntro}</p>
+        <pre className={shell.codeBlock}>
+          <code>{c.cliCode}</code>
+        </pre>
+
+        <p style={{ marginTop: '1.25rem' }}>
+          <a className={shell.btnGhost} href={tyutoolHref}>
+            {c.fullGuide} →
+          </a>
+        </p>
+      </section>
+
+      {/* Verify */}
+      <section id="verify" className={shell.block}>
+        <h2 className={shell.h2}>{c.verifyTitle}</h2>
+        <p className={shell.lead}>{c.verifyLead}</p>
+        <ul className={shell.checkList}>
+          {c.verifyPoints.map((p, i) => (
+            <li key={i}>{p}</li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Troubleshooting */}
+      <section id="trouble" className={shell.block}>
+        <h2 className={shell.h2}>{c.troubleTitle}</h2>
+        {c.trouble.map((item, i) => (
+          <div key={i} className={clsx(shell.callout, shell.calloutInfo)} style={{ display: 'block' }}>
+            <strong>{item.q}</strong>
+            <p>{item.a}</p>
+          </div>
+        ))}
+      </section>
+    </TutorialShell>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new **/tutorials** hub for user-facing guidance, plus the supporting building blocks. Everything is driven by a single manifest so new tutorials are one entry to add.

- **Manifest** (`src/data/tutorials.js`) — one source of truth: six filter sections (Basics · TuyaOpen IDE · TuyaOpen SDK · Projects · Tutorials · Community), per-locale labels, tags/levels, and card entries. Each entry declares `kind` (`markdown` \| `interactive` \| `external`) and `href`.
- **FlowingMenu sidebar** (React Bits + GSAP) — left sidebar to switch categories with the marquee-on-hover sweep; adapted to filter (buttons, not links), themed to the violet brand, theme-aware, and responsive (horizontal scroller on mobile).
- **BorderGlow cards** (React Bits) — cursor-following glow themed to the brand palette, light/dark aware, with an elegant interior (SVG icons, 3-line-clamped copy, meta footer, hover lift).
- **TutorialShell** — shared chrome so `markdown` and `interactive` tutorials look identical; a reading-progress TOC that tracks scroll (fixed sticky by using `overflow-x: clip` instead of `hidden`).
- **Reference templates** — interactive + markdown tutorial templates for future authors.
- **New guide** — “Use your license key”: write UUID/AuthKey with tyutool (GUI + CLI), verify activation, FAQ.
- **Cross-linking** — existing tyutool + licensing guides surface as cards; their back button returns to the hub when entered from it (`useFromTutorials` + `?from=tutorials`).
- **Navbar** — top-level “Tutorials” item (en/zh).
- **Cleanup** — tyutool-guide: removed two broken locally-hosted macOS driver screenshots (kept the driver download links).

## Test plan

- `npm run build` passes.
- `/tutorials` and `/zh/tutorials`: sidebar filters cards; category title + count update; empty sections show a friendly message.
- Card hover shows the themed glow; light + dark both verified in the built output.
- Tutorial detail pages: sticky reading-progress TOC follows scroll; back button returns to the hub when arrived via a card.
- Navbar “Tutorials” routes correctly in both locales.

## Notes / open questions
- Existing tyutool + license guides are filed under **Basics** (foundational how-tos) — easy to move if you'd prefer Community/elsewhere.
- Sidebar includes an **All** item at the top (default) so everything is browsable while most sections are still empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)