### PR TITLE
fix: disable Git metadata fetching for Docker builds

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,6 +65,8 @@ const config = {
         },
         docs: {
           sidebarPath: './sidebars.js',
+          showLastUpdateAuthor: false,
+          showLastUpdateTime: false,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl: 'https://github.com/Tuya-Community/TuyaOpen.io/edit/master/',
@@ -72,6 +74,8 @@ const config = {
         },
         blog: {
           showReadingTime: true,
+          showLastUpdateAuthor: false,
+          showLastUpdateTime: false,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl: 'https://github.com/Tuya-Community/TuyaOpen.io/edit/master/',
@@ -256,7 +260,7 @@ const config = {
         {
           title: 'Community',
           items: [
-                        {
+            {
               label: 'FAQ',
               to: '/faq',
             },
@@ -352,7 +356,7 @@ const config = {
   },
 
   plugins: [
-        // FAQ Blog — reverse chronological FAQ articles with cover images
+    // FAQ Blog — reverse chronological FAQ articles with cover images
     [
       '@docusaurus/plugin-content-blog',
       {
@@ -364,6 +368,8 @@ const config = {
         blogSidebarTitle: 'FAQ Articles',
         postsPerPage: 12,
         showReadingTime: true,
+        showLastUpdateAuthor: false,
+        showLastUpdateTime: false,
         editUrl: 'https://github.com/Tuya-Community/TuyaOpen.io/edit/master/',
         feedOptions: {
           type: 'all',

--- a/faq/index.md
+++ b/faq/index.md
@@ -2,6 +2,7 @@
 title: FAQ
 description: Frequently asked questions about IoT development, AIoT, embedded systems, open source platforms, and TuyaOpen.
 keywords: [faq, iot development, aiot, embedded systems, open source iot, tuyaopen faq]
+date: 2024-07-14
 ---
 
 # Frequently Asked Questions


### PR DESCRIPTION
Docusaurus v3.10+ tries to read Git history for blog posts/docs. During Docker build, .git directory is not available, causing:
  'Error: This Docusaurus site is outside any Git worktree.'

Disable showLastUpdateAuthor and showLastUpdateTime for:
- docs plugin
- main blog plugin
- FAQ blog plugin