### PR TITLE
Add TOC sidebar to the MCP smart-oven tutorial page

### DIFF
--- a/docs/tutorials/hardware-mcp-skills-smart-oven.md
+++ b/docs/tutorials/hardware-mcp-skills-smart-oven.md
@@ -12,13 +12,13 @@ keywords:
   - TuyaOpen
 ---
 
-# Hands-On: Give Your Hardware a Brain — Build MCP Skills That Let AI Control Real Devices
-
 Imagine telling your oven *"Preheat to 200 degrees and bake for 25 minutes"* — and it just... does it. No app, no buttons, no menu diving. Just natural language, understood by an AI agent, executed on real hardware.
 
 This guide shows you **exactly** how that works, using a **Smart Oven** project built with TuyaOpen. By the end, you'll know how to create your own hardware MCP skills for any device.
 
 ---
+
+<section id="what-youll-build" className="section">
 
 ## What You'll Build
 
@@ -35,7 +35,11 @@ An AI-powered Smart Oven where a chat agent can:
 
 The magic glue? **MCP Function Call** — the protocol that turns hardware operations into tools an AI agent can discover and invoke.
 
+</section>
+
 ---
+
+<section id="how-it-works" className="section">
 
 ## How It Works: The Architecture
 
@@ -51,7 +55,11 @@ graph LR
 
 **The key insight:** Every hardware capability (set temperature, read state, capture image) is registered as an **MCP tool** — a named function with typed parameters and a callback. The AI agent sees these tools, decides which to call based on user intent, and the callback drives the real hardware.
 
+</section>
+
 ---
+
+<section id="step-1-cloud-product" className="section">
 
 ## Step 1: Create the Cloud Product
 
@@ -118,7 +126,11 @@ This produces `tuya_dp_profile.h` — the contract between cloud and device:
 The full product creation flow is documented in [Create Your Product & Agent](/docs/cloud/tuya-cloud/creating-new-product). For the oven demo, you can also let the AI Agent generate the product and DPs for you using the `/tuya-iot-platform` skill in TuyaOpen IDE.
 :::
 
+</section>
+
 ---
+
+<section id="step-2-mock-hardware" className="section">
 
 ## Step 2: Implement the Mock Hardware Layer
 
@@ -158,7 +170,11 @@ OPERATE_RET app_oven_set_temp(int temp_c) {
 }
 ```
 
+</section>
+
 ---
+
+<section id="step-3-register-tools" className="section">
 
 ## Step 3: Register MCP Tools (The Core Step)
 
@@ -254,7 +270,11 @@ static OPERATE_RET __oven_get_state_cb(const MCP_PROPERTY_LIST_T *properties,
 }
 ```
 
+</section>
+
 ---
+
+<section id="step-4-wire-boot" className="section">
 
 ## Step 4: Wire It Into the Boot Sequence
 
@@ -269,7 +289,11 @@ In your `app_chat_bot.c`, call your MCP init **right after** `ai_mcp_init()`:
 
 Tools register automatically when MQTT connects. That's it.
 
+</section>
+
 ---
+
+<section id="step-5-build-test" className="section">
 
 ## Step 5: Build and Test
 
@@ -287,7 +311,11 @@ Verify the tool appears in the agent's tool list, then try these interactions:
 | "Is it still on? How hot?" | `oven.get_state()` | Returns `{switch_on: true, temp_set: 200, ...}` |
 | "Take a photo and check if the cake is done" | `device.camera_shot()` | AI receives a JPEG and can visually inspect |
 
+</section>
+
 ---
+
+<section id="complete-tool-set" className="section">
 
 ## The Complete Tool Set
 
@@ -317,7 +345,11 @@ Here's the full set of MCP tools for the Smart Oven:
 | `reheat` | 120°C | 5 min | Leftovers |
 | `warm` | 80°C | 30 min | Keep food warm |
 
+</section>
+
 ---
+
+<section id="ai-coding-prompts" className="section">
 
 ## AI Coding Prompts: Tips for Developers
 
@@ -409,7 +441,11 @@ Create a complete Smart Oven project:
 
 **Why it works:** The `/tuyaopen-dev-loop` skill orchestrates the full cloud-to-device workflow.
 
+</section>
+
 ---
+
+<section id="key-takeaways" className="section">
 
 ## Key Takeaways
 
@@ -420,7 +456,11 @@ Create a complete Smart Oven project:
 5. **Keep hardware separate from MCP** — Your `app_oven.c` handles hardware; `app_oven_mcp.c` handles tool registration. Clean separation.
 6. **Return structured data** — JSON responses with `ok: false` + available options let the AI self-correct.
 
+</section>
+
 ---
+
+<section id="next-steps" className="section">
 
 ## Next Steps
 
@@ -429,3 +469,5 @@ Create a complete Smart Oven project:
 - [Hardware Peripheral Skills](/docs/duckyclaw/hardware-skill) — Built-in GPIO, ADC, I2C, UART, PWM tools
 - [MCP Server API](/docs/cloud/device-ai/ai-components/ai-mcp-server) — Complete MCP server documentation
 - [Designing Device MCP Tools](/docs/cloud/device-ai/concepts/designing-device-mcp-tools) — Best practices for tool design
+
+</section>

--- a/docs/tutorials/zh/hardware-mcp-skills-smart-oven.md
+++ b/docs/tutorials/zh/hardware-mcp-skills-smart-oven.md
@@ -12,13 +12,13 @@ keywords:
   - TuyaOpen
 ---
 
-# 实战：给你的硬件装上大脑 — 构建让 AI 控制真实设备的 MCP 技能
-
 想象一下，你对烤箱说 *"预热到 200 度，烤 25 分钟"* — 它就照做了。不用打开 App，不用找按钮，不用翻菜单。只需自然语言，AI Agent 理解你的意图，在真实硬件上执行。
 
 本指南将用 TuyaOpen 构建的 **智能烤箱** 项目，**详细** 展示这套机制是如何工作的。读完后，你将掌握如何为任意设备创建自己的硬件 MCP 技能。
 
 ---
+
+<section id="what-youll-build" className="section">
 
 ## 你将构建什么
 
@@ -35,7 +35,11 @@ keywords:
 
 核心粘合剂？**MCP Function Call** — 将硬件操作变成 AI Agent 可以发现并调用的工具的协议。
 
+</section>
+
 ---
+
+<section id="how-it-works" className="section">
 
 ## 架构：它是如何工作的
 
@@ -51,7 +55,11 @@ graph LR
 
 **核心洞察：** 每一个硬件能力（设置温度、读取状态、拍照）都被注册为一个 **MCP 工具** — 一个带类型参数和回调的命名函数。AI Agent 看到这些工具，根据用户意图决定调用哪个，回调函数驱动真实硬件。
 
+</section>
+
 ---
+
+<section id="step-1-cloud-product" className="section">
 
 ## 步骤 1：创建云端产品
 
@@ -118,7 +126,11 @@ tuyaopen dp generate --target embedded
 完整的产品创建流程详见[创建你的产品与 Agent](/docs/cloud/tuya-cloud/creating-new-product)。烤箱 Demo 中，你也可以在 TuyaOpen IDE 中使用 `/tuya-iot-platform` 技能让 AI Agent 自动生成产品和 DP。
 :::
 
+</section>
+
 ---
+
+<section id="step-2-mock-hardware" className="section">
 
 ## 步骤 2：实现 Mock 硬件层
 
@@ -158,7 +170,11 @@ OPERATE_RET app_oven_set_temp(int temp_c) {
 }
 ```
 
+</section>
+
 ---
+
+<section id="step-3-register-tools" className="section">
 
 ## 步骤 3：注册 MCP 工具（核心步骤）
 
@@ -254,7 +270,11 @@ static OPERATE_RET __oven_get_state_cb(const MCP_PROPERTY_LIST_T *properties,
 }
 ```
 
+</section>
+
 ---
+
+<section id="step-4-wire-boot" className="section">
 
 ## 步骤 4：接入启动流程
 
@@ -269,7 +289,11 @@ static OPERATE_RET __oven_get_state_cb(const MCP_PROPERTY_LIST_T *properties,
 
 MQTT 连接后工具会自动注册。就这么简单。
 
+</section>
+
 ---
+
+<section id="step-5-build-test" className="section">
 
 ## 步骤 5：构建与测试
 
@@ -287,7 +311,11 @@ tos.py build
 | "还开着吗？多热？" | `oven.get_state()` | 返回 `{switch_on: true, temp_set: 200, ...}` |
 | "拍张照片看看蛋糕好了没" | `device.camera_shot()` | AI 收到 JPEG 并视觉判断 |
 
+</section>
+
 ---
+
+<section id="complete-tool-set" className="section">
 
 ## 完整工具集
 
@@ -317,7 +345,11 @@ tos.py build
 | `reheat` | 120°C | 5 分钟 | 加热剩菜 |
 | `warm` | 80°C | 30 分钟 | 保温 |
 
+</section>
+
 ---
+
+<section id="ai-coding-prompts" className="section">
 
 ## AI 编程提示词技巧
 
@@ -408,7 +440,11 @@ tos.py build
 
 **为什么有效：** `/tuyaopen-dev-loop` 技能编排了从云端到设备的完整工作流。
 
+</section>
+
 ---
+
+<section id="key-takeaways" className="section">
 
 ## 核心要点
 
@@ -419,7 +455,11 @@ tos.py build
 5. **硬件与 MCP 分离** — `app_oven.c` 负责硬件，`app_oven_mcp.c` 负责工具注册。职责清晰。
 6. **返回结构化数据** — JSON 响应带 `ok: false` + 可选项，让 AI 能自我纠正。
 
+</section>
+
 ---
+
+<section id="next-steps" className="section">
 
 ## 下一步
 
@@ -428,3 +468,5 @@ tos.py build
 - [硬件外设技能](/docs/duckyclaw/hardware-skill) — 内置 GPIO、ADC、I2C、UART、PWM 工具
 - [MCP Server API](/docs/cloud/device-ai/ai-components/ai-mcp-server) — MCP 服务端完整文档
 - [设计设备 MCP 工具](/docs/cloud/device-ai/concepts/designing-device-mcp-tools) — 工具设计最佳实践
+
+</section>

--- a/src/pages/learn/hardware-mcp-skills-smart-oven.jsx
+++ b/src/pages/learn/hardware-mcp-skills-smart-oven.jsx
@@ -1,7 +1,70 @@
-import CommunityProjectPage from '@site/src/components/CommunityProjectPage';
-import bodyEn from '@site/docs/tutorials/hardware-mcp-skills-smart-oven.md';
-import bodyZh from '@site/docs/tutorials/zh/hardware-mcp-skills-smart-oven.md';
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import TutorialShell from '@site/src/components/TutorialShell';
+import BodyEn from '@site/docs/tutorials/hardware-mcp-skills-smart-oven.md';
+import BodyZh from '@site/docs/tutorials/zh/hardware-mcp-skills-smart-oven.md';
 
-export default () => (
-  <CommunityProjectPage id="hardware-mcp-skills-smart-oven" bodyEn={bodyEn} bodyZh={bodyZh} />
-);
+/* =========================================================================
+ * LEARN: Hands-On — Build MCP Skills That Let AI Control Real Devices
+ * (kind: 'markdown', category: 'tutorials')
+ * Renders through TutorialShell directly (not CommunityProjectPage) so it
+ * gets the same "On this page" TOC sidebar as the other tutorial-category
+ * markdown pages (e.g. tuyaopen-ide-overview) — nav ids below must match the
+ * <section id="..."> wrappers in the two source .md files.
+ * ========================================================================= */
+
+const content = {
+  en: {
+    badge: 'Tutorials',
+    title: 'Hands-On: Build MCP Skills That Let AI Control Real Devices',
+    subtitle:
+      "Create hardware MCP skills (tool functions) that let an AI agent control physical devices — build an AI Smart Oven from scratch with TuyaOpen's MCP function-call framework.",
+    meta: ['Intermediate', '30 min', 'MCP'],
+    nav: [
+      { id: 'what-youll-build', label: "What You'll Build" },
+      { id: 'how-it-works', label: 'How It Works' },
+      { id: 'step-1-cloud-product', label: '1. Cloud Product' },
+      { id: 'step-2-mock-hardware', label: '2. Mock Hardware' },
+      { id: 'step-3-register-tools', label: '3. Register MCP Tools' },
+      { id: 'step-4-wire-boot', label: '4. Wire Boot Sequence' },
+      { id: 'step-5-build-test', label: '5. Build and Test' },
+      { id: 'complete-tool-set', label: 'Complete Tool Set' },
+      { id: 'ai-coding-prompts', label: 'AI Coding Prompts' },
+      { id: 'key-takeaways', label: 'Key Takeaways' },
+      { id: 'next-steps', label: 'Next Steps' },
+    ],
+  },
+  zh: {
+    badge: '教程',
+    title: '实战：给你的硬件装上大脑 — 构建让 AI 控制真实设备的 MCP 技能',
+    subtitle:
+      '学习如何创建硬件 MCP 技能（工具函数），让 AI Agent 控制物理设备——用 TuyaOpen 的 MCP Function Call 框架从零构建一台 AI 智能烤箱。',
+    meta: ['进阶', '30 分钟', 'MCP'],
+    nav: [
+      { id: 'what-youll-build', label: '你将构建什么' },
+      { id: 'how-it-works', label: '架构原理' },
+      { id: 'step-1-cloud-product', label: '一、创建云端产品' },
+      { id: 'step-2-mock-hardware', label: '二、Mock 硬件层' },
+      { id: 'step-3-register-tools', label: '三、注册 MCP 工具' },
+      { id: 'step-4-wire-boot', label: '四、接入启动流程' },
+      { id: 'step-5-build-test', label: '五、构建与测试' },
+      { id: 'complete-tool-set', label: '完整工具集' },
+      { id: 'ai-coding-prompts', label: 'AI 编程提示词' },
+      { id: 'key-takeaways', label: '核心要点' },
+      { id: 'next-steps', label: '下一步' },
+    ],
+  },
+};
+
+export default function HardwareMcpSkillsSmartOven() {
+  const { i18n } = useDocusaurusContext();
+  const locale = i18n.currentLocale === 'zh' ? 'zh' : 'en';
+  const c = content[locale];
+  const Body = locale === 'zh' ? BodyZh : BodyEn;
+
+  return (
+    <TutorialShell badge={c.badge} title={c.title} subtitle={c.subtitle} meta={c.meta} nav={c.nav} markdown>
+      <Body />
+    </TutorialShell>
+  );
+}


### PR DESCRIPTION
## Summary
- The `hardware-mcp-skills-smart-oven` Learn page (category: `tutorials`) was rendering through `CommunityProjectPage`, which is built for community-project cards and never shows the "On this page" TOC sidebar.
- Switched it to use `TutorialShell` directly (same as other tutorial detail pages, e.g. `tuyaopen-ide-overview`), with a category-correct "Tutorials"/"教程" badge and a `nav` list for the sidebar.
- Wrapped each major markdown section (both EN and ZH source files) in `<section id="...">` so the sidebar's scroll-tracking/highlight works.
- Removed a duplicate H1 in the markdown body (the page hero already renders the title), which previously caused the title to appear twice with slightly different wording.

## Test plan
- [x] Verified in a local dev server that `/learn/hardware-mcp-skills-smart-oven?from=learn` now shows the "Back to Learn" breadcrumb, "Tutorials" badge, and "On this page" sidebar, matching other tutorial pages' style.
- [x] Verified scroll-tracking highlights the active section as you scroll.
- [x] Verified the Chinese version (`/zh/learn/hardware-mcp-skills-smart-oven`) via a production build — sidebar labels, badge, and no duplicate title.
- [x] Confirmed the standalone `/docs/tutorials/hardware-mcp-skills-smart-oven` route (which shares the same source `.md` files) still resolves its title from frontmatter as expected.